### PR TITLE
Added a tqdm toggle

### DIFF
--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -15,7 +15,7 @@ basic_branches = ['event_number', 'start_time', 'stop_time',
                   'interactions.s1_area_correction', 'interactions.s2_area_correction',
                   'interactions.x', 'interactions.y', 'interactions.z', 'interactions.drift_time']
 
-# Tqdm on or off. Set to False for off
+# Progress bar on or off. Set to False for off
 tqdm_on = True
 
 ##

--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -15,6 +15,8 @@ basic_branches = ['event_number', 'start_time', 'stop_time',
                   'interactions.s1_area_correction', 'interactions.s2_area_correction',
                   'interactions.x', 'interactions.y', 'interactions.z', 'interactions.drift_time']
 
+# Tqdm on or off. Set to False for off
+tqdm_on = True
 
 ##
 # Processed data access options

--- a/hax/paxroot.py
+++ b/hax/paxroot.py
@@ -75,10 +75,17 @@ def loop_over_datasets(datasets_names, event_function=lambda event: None, branch
                 t.SetBranchStatus(bn, 1)
 
         try:
-            for event_i in tqdm(range(n_events)):
-                t.GetEntry(event_i)
-                event = t.events
-                event_function(event)
+            if hax.config['tqdm_on']:
+                for event_i in tqdm(range(n_events)):
+                    t.GetEntry(event_i)
+                    event = t.events
+                    event_function(event)
+            else:
+                for event_i in range(n_events):
+                    t.GetEntry(event_i)
+                    event = t.events
+                    event_function(event)
+
         except StopEventLoop:
             rootfile.Close()
         except Exception as e:

--- a/hax/paxroot.py
+++ b/hax/paxroot.py
@@ -75,16 +75,13 @@ def loop_over_datasets(datasets_names, event_function=lambda event: None, branch
                 t.SetBranchStatus(bn, 1)
 
         try:
-            if hax.config['tqdm_on']:
-                for event_i in tqdm(range(n_events)):
-                    t.GetEntry(event_i)
-                    event = t.events
-                    event_function(event)
-            else:
-                for event_i in range(n_events):
-                    t.GetEntry(event_i)
-                    event = t.events
-                    event_function(event)
+            source = range(n_events)
+            if hax.config.get('tqdm_on', True):
+                source = tqdm(source)
+            for event_i in source:
+                t.GetEntry(event_i)
+                event = t.events
+                event_function(event)
 
         except StopEventLoop:
             rootfile.Close()


### PR DESCRIPTION
When I tried to use hax.minitrees.load() multiple times in the same output(I put it in a for loop), the tqdm package would sometimes give an I/O error, causing the loop to end. This is just a small fix that allows you to toggle the tqdm bar on or off. It is on by default (tqdm_on = True) and in a notebook you can change it by running hax.config.update(tqdm_on = False)