### PR TITLE
Added a way to apply a function to a list of datasets without needing globals etc. to retain the function's return values.

### DIFF
--- a/hax/paxroot.py
+++ b/hax/paxroot.py
@@ -5,7 +5,7 @@ import os
 
 from tqdm import tqdm
 import ROOT
-from pax.plugins.io.ROOTClass import load_event_class, load_pax_event_class_from_root, ShutUpROOT
+from pax.plugins.io.ROOTClass import load_event_class, load_pax_event_class_from_root
 from pax.exceptions import MaybeOldFormatException
 
 import hax
@@ -33,11 +33,10 @@ def open_pax_rootfile(filename):
     return ROOT.TFile(filename)
 
 
-
-
 # An exception you can raise to stop looping over the current dataset
 class StopEventLoop(Exception):
     pass
+
 
 def function_results_datasets(datasets_names, event_function=lambda event, **kwargs: None,
                               branch_selection='basic', kwargs=dict()):
@@ -89,11 +88,14 @@ def function_results_datasets(datasets_names, event_function=lambda event, **kwa
             rootfile.Close()
             raise e
 
+
 def loop_over_datasets(datasets_names, event_function=lambda event: None,
                        branch_selection='basic'):
     """Execute event_function(event) over all events in the dataset(s)
-    Does not return anything: you have to keep track of results yourself (global vars, function attrs, classes, ...)
-    branch selection: can be None (all branches are read), 'basic' (hax.config['basic_branches'] are read), or a list of branches to read.
+    Does not return anything: you have to keep track of results yourself (global vars, function attrs,
+    classes, ...)
+    branch selection: can be None (all branches are read), 'basic' (hax.config['basic_branches'] are read), or a list of
+    branches to read.
     """
     for result in function_results_datasets(datasets_names, event_function, branch_selection):
         # do nothing with the results

--- a/hax/paxroot.py
+++ b/hax/paxroot.py
@@ -39,11 +39,15 @@ def open_pax_rootfile(filename):
 class StopEventLoop(Exception):
     pass
 
+def function_results_datasets(datasets_names, event_function=lambda event, **kwargs: None,
+                              branch_selection='basic', kwargs=dict()):
+    """Returns a generator which yields the return values of event_function(event) over the datasets specified in
+    datasets_names.
 
-def loop_over_datasets(datasets_names, event_function=lambda event: None, branch_selection='basic'):
-    """Execute event_function(event) over all events in the dataset(s)
-    Does not return anything: you have to keep track of results yourself (global vars, function attrs, classes, ...)
-    branch selection: can be None (all branches are read), 'basic' (hax.config['basic_branches'] are read), or a list of branches to read.
+    Parameters are equivalent to loop_over_datasets, except for the addition of kwargs, which allows for additional
+    arguments to be passed to event_function if the function is able to take more than one. kwargs should be a dict
+    mapping argument names to their respective values.
+    Example: kwargs={'x': 2, 'y': 3} --> function called like: event_function(event, x=2, y=3)
     """
     if isinstance(datasets_names, str):
         datasets_names = [datasets_names]
@@ -78,12 +82,22 @@ def loop_over_datasets(datasets_names, event_function=lambda event: None, branch
             for event_i in tqdm(range(n_events)):
                 t.GetEntry(event_i)
                 event = t.events
-                event_function(event)
+                yield event_function(event, **kwargs)
         except StopEventLoop:
             rootfile.Close()
         except Exception as e:
             rootfile.Close()
             raise e
+
+def loop_over_datasets(datasets_names, event_function=lambda event: None,
+                       branch_selection='basic'):
+    """Execute event_function(event) over all events in the dataset(s)
+    Does not return anything: you have to keep track of results yourself (global vars, function attrs, classes, ...)
+    branch selection: can be None (all branches are read), 'basic' (hax.config['basic_branches'] are read), or a list of branches to read.
+    """
+    for result in function_results_datasets(datasets_names, event_function, branch_selection):
+        # do nothing with the results
+        pass
 
 # For backward compatibility
 loop_over_dataset = loop_over_datasets


### PR DESCRIPTION
Changed 'loop_over_datasets' into 'function_results_datasets', which allows to apply a function to datasets and, at the same time, to receive the function's return value for each event. Created a new 'loop_over_datasets' with the same functionality and parameters as the old one to maintain backward compatibility.