### PR TITLE
Fixes for pmt_plot

### DIFF
--- a/hax/pmt_plot.py
+++ b/hax/pmt_plot.py
@@ -25,54 +25,78 @@ from hax.utils import flatten_dict
 ##
 
 # Convert PMT/channel map to record array
-config = load_configuration('XENON1T')
+pax_config = load_configuration('XENON1T')      # TODO: depends on experiment, should do after init
+pmt_data = pd.DataFrame([flatten_dict(info, separator=':') for info in pax_config['DEFAULT']['pmts']])
+pmt_numbering_start = pmt_data['pmt_position'].min()
 
-pmt_data = pd.DataFrame([flatten_dict(info, sep='_') for info in config['DEFAULT']['pmts']])
-
-pmt_data['PMT'] = pmt_data['pmt_position']
-del pmt_data['pmt_position']
-
-# Split connector + channel information into separate fields
-# Note to anyone reading this: always make separate fields for separate information
-for keyname in ('high_voltage_connector', 'signal_connector'):
-    main = [int(q.split('.')[0]) for q in pmt_data[keyname]]
-    channel = [int(q.split('.')[1]) for q in pmt_data[keyname]]
-    pmt_data[keyname] = main
-    pmt_data[keyname + '_channel'] = channel
-        
-pmt_numbering_start = pmt_data['PMT'].min()
 
 ##
 # Plotting functions
 ##
 
-def _plot_pmts(ax, pmt_selection, 
-               xkey, ykey=None, 
-               color=None, size=None, tight_limits=False, 
-               **kwargs):
-    """Makes a scatter plot of pmts on ax.
-    Plot only pmts for which pmt_selection is True. xkey and ykey are used for x, y.
-    Returns the return value of plt.scatter (useful to define a colorbar).
-    """
-    if ykey is not None:
-        x, y, pmt_numbers = pmt_data[pmt_selection][[xkey, ykey, 'PMT']].as_matrix().T
-        xlabel = xkey
-        ylabel = ykey
+def _pad_to_length_of(a, b):
+    """Pads a with zeros until it has the length of b"""
+    lendiff = len(b) - len(a)
+    if lendiff < 0:
+        raise ValueError("Cannot pad a negative number of zeros!")
+    elif lendiff > 0:
+        return np.concatenate((a, np.zeros(lendiff)))
     else:
-        # No ykey is given: just stack pmts with same xkey in y.
-        plot_keys, pmt_numbers = pmt_data[pmt_selection][[xkey, 'PMT']].as_matrix().T
-        
-        labels = sorted(list(set(plot_keys)))
+        return a
+
+
+def _plot_pmts(ax, xkey, color, size,
+               pmt_selection=None,
+               ykey=None,
+               tight_limits=False,
+               **kwargs):
+    """Makes a scatter plot of pmts on ax, with xkey (index in pmt_data) on x axis.
+     - color, size: control PMT marker properties
+     - ykey: index in pmt_data. If given, is put on y axis. If not,  make y axis a meaningless int to distringuish pmts.
+     - pmt_selection: legal index array to pmt_data, selects pmts to plot
+     - tight_limits: if True, clip limits to min and max of xkey and ykey
+    Any kwargs will be passed to ax.scatter
+
+    Returns the return value of ax.scatter (useful to define a colorbar).
+    """
+    # Pad color and size with zeros, to support just TPC PMTs, for example
+    color = _pad_to_length_of(color, pmt_data)
+    size = _pad_to_length_of(size, pmt_data)
+
+    if pmt_selection is None:
+        # Select all PMTs
+        pmt_selection = np.ones(len(pmt_data), dtype=np.bool_)
+
+    xlabel = xkey
+
+    if ykey is None:
+        # No y key given, make y a duplication counter
+        ykey = 'pmt_position'
+        ylabel = 'Meaningless integer'
+
+        x, pmt_numbers = pmt_data[pmt_selection][[xkey, 'pmt_position']].as_matrix().T
+
         n_occs = defaultdict(float)
         y = []
-        x = []
-        for i, k in enumerate(plot_keys):
-            x.append(labels.index(k))
-            y.append(n_occs[k])
-            n_occs[k] += 1
-        xlabel = xkey
-        ylabel = ''
-    
+        for i, q in enumerate(x):
+            y.append(n_occs[q])
+            n_occs[q] += 1
+        y = np.array(y)
+
+    else:
+        ylabel = ykey
+        x, y, pmt_numbers = pmt_data[pmt_selection][[xkey, ykey, 'pmt_position']].as_matrix().T
+
+    # For xkey and ykey, if integer values, change to a categorical axis
+    tick_labels = {}
+    for q, qname in ((x, 'x'), (y, 'y')):
+        if isinstance(q[0], (int, np.int, np.int32, np.int64)):
+            labels = sorted(list(set(q)))
+            for i, w in enumerate(q):
+                q[i] = labels.index(w)
+            tick_labels[qname] = labels
+            locals()[qname] = q
+
     # Plot the PMT as circles with specified colors and sizes
     sc = ax.scatter(x, y, 
                     c=color[pmt_selection], s=size[pmt_selection], 
@@ -84,54 +108,68 @@ def _plot_pmts(ax, pmt_selection,
                 fontsize=8, va='center', ha='center')
                    
     # Set limits and labels
-    lim_scale = 1.3
+    lim_scale = 1
     if tight_limits:
         ax.set_xlim(x.min() * lim_scale, x.max() * lim_scale)
         ax.set_ylim(y.min() * lim_scale, y.max() * lim_scale)
-    if ykey is None:
-        plt.xticks(np.arange(len(labels)), labels, rotation='vertical')
-        #ax.set_xticks(x)
-        #ax.set_xticklabels(labels, rotation='vertical')
     ax.set_xlabel(xlabel)
-    ax.set_ylabel(ylabel)   
-                   
+    ax.set_ylabel(ylabel)
+
+    # Set categorical ticks
+    for qname, labels in tick_labels.items():
+        getattr(plt, qname + 'ticks')(np.arange(len(labels)),
+                                      labels,
+                                      rotation='vertical' if qname == 'x' else 'horizontal')
+
     return sc
 
 
 def plot_on_pmt_arrays(color=None, size=None,
                        geometry='physical',
-                       fontsize=8,title=None,
+                       title=None,
                        scatter_kwargs=None, colorbar_kwargs=None):
     """Plot a scatter plot of PMTs in a specified geometry, with a specified color and size of the markers.
         Color or size must be per-PMT array that is indexable by another array, i.e. must be np.array and not list.
         scatter_kwargs will be passed to plt.scatter
         colorbar_kwargs will be passed to plt.colorbar
-        geometry can be 'physical', or any key from pmt_data
+        geometry can be 'physical', a key from pmt_data, or a 2-tuple of keys from pmt_data.
     """
     if scatter_kwargs is None:
         scatter_kwargs = dict()
     if colorbar_kwargs is None:
         colorbar_kwargs = dict()
+
     if size is None:
         if color is None:
             raise ValueError("Give me at least size or color")
-        size = 1000 * color/np.nanmean(color)
+        size = 1000 * np.array(color)/np.nanmean(color)
     if color is None:
-        color = 'blue'
+        color = 0 * np.ones(len(size))
+
+    # Geometry shortcuts
+    geometry = dict(digitizer=('digitizer:module', 'digitizer:channel'),
+                    amplifier=('amplifier:serial', 'amplifier:plug'),
+                    high_voltage=('high_voltage:connector', 'high_voltage:channel'),
+                    signal=('signal:connector', 'signal:channel'),
+                    ).get(geometry, geometry)
         
     if geometry == 'physical':
         # For the physical geometry, plot the top and bottom arrays side-by-side.
         _, (ax1, ax2) = plt.subplots(1, 2, sharey=True, figsize=(20, 7))
         
         if title is not None:
-            plt.suptitle(title,fontsize=24,x=0.435,y=1.0)
-                   
+            plt.suptitle(title, fontsize=24, x=0.435, y=1.0)
+
+        # We must extract vmin and max explicitly, since we want two plots with the same scale
+        scatter_kwargs.setdefault('vmin', np.nanmin(color))
+        scatter_kwargs.setdefault('vmax', np.nanmax(color))
         for array_name, ax in (('top', ax1), ('bottom', ax2)):
-            sc = _plot_pmts(ax=ax, 
-                            pmt_selection=(pmt_data['array'] == array_name).as_matrix(), 
-                            xkey='position_x', ykey='position_y', 
-                            color=color, size=size, 
-                            tight_limits=True, **scatter_kwargs)
+            sc = _plot_pmts(ax=ax,
+                            xkey='position:x', ykey='position:y',
+                            color=color, size=size,
+                            pmt_selection=(pmt_data['array'] == array_name).as_matrix(),
+                            tight_limits=True,
+                            **scatter_kwargs)
             ax.set_title('%s array' % array_name.capitalize())
                    
         cax, _ = matplotlib.colorbar.make_axes([ax1, ax2])
@@ -139,18 +177,12 @@ def plot_on_pmt_arrays(color=None, size=None,
             
     else:
         plt.figure(figsize=(20, 8))
-        if geometry + '_channel' in pmt_data.columns:
-            sc = _plot_pmts(ax=plt.gca(), 
-                            pmt_selection=slice(None), 
-                            xkey=geometry, ykey=geometry + '_channel',
-                            color=color, size=size,
-                            **scatter_kwargs)
-            plt.colorbar(sc, **colorbar_kwargs)
-            
+        if isinstance(geometry, tuple) and len(geometry) == 2:
+            xkey, ykey = geometry
         else:
-            sc = _plot_pmts(ax=plt.gca(), 
-                            pmt_selection=slice(None), 
-                            xkey=geometry,
-                            color=color, size=size,
-                            **scatter_kwargs)
-            plt.colorbar(sc, **colorbar_kwargs)
+            xkey, ykey = geometry, None
+        sc = _plot_pmts(ax=plt.gca(),
+                        xkey=xkey, ykey=ykey,
+                        color=color, size=size,
+                        **scatter_kwargs)
+        plt.colorbar(sc, **colorbar_kwargs)

--- a/hax/runs.py
+++ b/hax/runs.py
@@ -66,7 +66,7 @@ def update_datasets():
                                     'tags.name'
                                     ]):
             doc['tags'] = ','.join([t['name'] for t in doc.get('tags', [])])   # Convert tags to single string
-            doc = flatten_dict(doc, sep='__')
+            doc = flatten_dict(doc, separator='__')
             del doc['_id']   # Remove the Mongo document ID
             doc['raw_data_subfolder'] = ''      # For the moment, everything is in one folder
             docs.append(doc)

--- a/hax/utils.py
+++ b/hax/utils.py
@@ -38,16 +38,16 @@ def get_xenon100_dataset_number(dsetname):
     return int(date) * 10000 + int(time)
 
 
-def flatten_dict(d, sep=':', _parent_key=''):
-    """Flatten nested dictionaries into a single dictionary, indicating levels by sep
-    Leave _parent_key argument alone, used for recursion.
+def flatten_dict(d, separator=':', _parent_key=''):
+    """Flatten nested dictionaries into a single dictionary, indicating levels by separator
+    Don't set _parent_key argument, this is used for recursive calls.
     Stolen from http://stackoverflow.com/questions/6027558
     """
     items = []
     for k, v in d.items():
-        new_key = _parent_key + sep + k if _parent_key else k
+        new_key = _parent_key + separator + k if _parent_key else k
         if isinstance(v, collections.MutableMapping):
-            items.extend(flatten_dict(v, sep=sep, _parent_key=new_key, ).items())
+            items.extend(flatten_dict(v, separator=separator, _parent_key=new_key).items())
         else:
             items.append((new_key, v))
     return dict(items)


### PR DESCRIPTION
This fixes #15, and makes pmt_plot a bit more robust overall (for example, errors less often if you don't specify all arguments). Categorical axes are now supported in x and y. Aliases for the geometry are available, so instead of saying `geometry=('amplifier:serial', 'amplifier:plug')` you can just say `geometry='amplifier'`. Similarly for 'digitizer', 'high_voltage' and 'signal'. 

This requires https://github.com/XENON1T/pax/pull/364. Conversely once we merge https://github.com/XENON1T/pax/pull/364 hax's pmt plot will no longer work until we merge this.

Example:
```
from hax import pmt_plot
hax.pmt_plot.plot_on_pmt_arrays(np.arange(254), geometry='amplifier')
```

![index](https://cloud.githubusercontent.com/assets/4354311/15541431/bcfc0d98-228c-11e6-876b-15f3dd2edf39.png)

(of course you would normally ensure the PMTs' circles' sizes are sane too, e.g. pass `size=1000 * np.ones(254)` too).