### PR TITLE
Improvements for basic treemakers

### DIFF
--- a/hax/__init__.py
+++ b/hax/__init__.py
@@ -10,7 +10,8 @@ __version__ = '0.4.1'
 # I am surprised this works (even if we do 'from hax' instead of 'from .')
 # as some of the modules do 'import hax' or 'from hax.foo import bar'.. shouldn't we get circular imports??
 # I need to read up on python packaging more...
-from . import ipython, minitrees, paxroot, pmt_plot, raw_data, runs, utils, treemakers, data_extractor
+from . import ipython, minitrees, paxroot, pmt_plot, raw_data, runs, utils, treemakers, data_extractor, \
+              slow_control, trigger_data
 
 # Store the directory of hax (i.e. this file's directory) as HAX_DIR
 hax_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))

--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -106,7 +106,7 @@ minitree_paths = ['.', '/cfs/klemming/projects/xenon/common/PaxReprocessed_9/goo
 
 [midway]
 cax_key = 'midway'
-raw_data_local_path = '/project/lgrandi/xenon1t'
+raw_data_local_path = '/project/lgrandi/xenon1t/raw'
 
 
 [jelle-SATELLITE-Z30-B]

--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -11,9 +11,10 @@ experiment = 'XENON1T'
 basic_branches = ['event_number', 'start_time', 'stop_time',
                   's1s', 's2s',
                   'peaks.area', 'peaks.type', 'peaks.area_fraction_top', 'peaks.detector',
+                  'peaks.range_area_decile[11]',
                   'interactions.s1', 'interactions.s2',
                   'interactions.s1_area_correction', 'interactions.s2_area_correction',
-                  'interactions.x', 'interactions.y', 'interactions.z', 'interactions.drift_time']
+                  'interactions.x', 'interactions.y', 'interactions.z', 'interactions.drift_time',]
 
 # Progress bar on or off. Set to False for off
 tqdm_on = True

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -195,7 +195,7 @@ def get(run_name, treemaker, force_reload=False):
     return minitree_path
 
 
-def load(datasets, treemakers=('Basics', 'MainInteraction'), force_reload=False):
+def load(datasets, treemakers='Basics', force_reload=False):
     """Return pandas DataFrame with minitrees of several datasets.
       datasets: names or numbers of datasets (without .root) to load
       treemakers: treemaker class (or string with name of class) or list of these to load. Defaults to 'Basics'.
@@ -205,6 +205,9 @@ def load(datasets, treemakers=('Basics', 'MainInteraction'), force_reload=False)
         datasets = [datasets]
     if isinstance(treemakers, (type, str)):
         treemakers = [treemakers]
+
+    # Add the "Fundamentals" treemaker to the beginning; we always want to load this.
+    treemakers = ['Fundamentals'] + treemakers
 
     combined_dataframes = []
 

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -195,7 +195,7 @@ def get(run_name, treemaker, force_reload=False):
     return minitree_path
 
 
-def load(datasets, treemakers='Basics', force_reload=False):
+def load(datasets, treemakers=('Basics', 'MainInteraction'), force_reload=False):
     """Return pandas DataFrame with minitrees of several datasets.
       datasets: names or numbers of datasets (without .root) to load
       treemakers: treemaker class (or string with name of class) or list of these to load. Defaults to 'Basics'.

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -30,9 +30,12 @@ class TreeMaker(object):
     for their treemaker
     """
     cache_size = 1000
-    extra_branches = tuple()
+    branch_selection = None     # List of branches to load during iteration over events
+    extra_branches = tuple()    # If the above is empty, load basic branches (set in hax.config) plus these.
 
     def __init__(self):
+        if not self.branch_selection:
+            self.branch_selection = hax.config['basic_branches'] + list(self.extra_branches)
         self.cache = []
 
     def extract_data(self, event):
@@ -47,7 +50,7 @@ class TreeMaker(object):
         self.run_name = runs.get_run_name(dataset)
         self.run_number = runs.get_run_number(dataset)
         loop_over_dataset(dataset, self.process_event,
-                          branch_selection=hax.config['basic_branches'] + list(self.extra_branches))
+                          branch_selection=self.branch_selection)
         self.check_cache(force_empty=True)
         if not hasattr(self, 'data'):
             raise RuntimeError("Not a single event was extracted from dataset %s!" % dataset)

--- a/hax/raw_data.py
+++ b/hax/raw_data.py
@@ -20,13 +20,13 @@ def inspect_events_from_minitree(events, *args, **kwargs):
     """
     if isinstance(events, pd.Series):
         events = pd.DataFrame([events])
-    for dataset_number, evts in events.groupby('dataset_number'):
+    for dataset_number, evts in events.groupby('run_number'):
         event_numbers = evts.event_number.values
         inspect_events(dataset_number, event_numbers, *args, **kwargs)
 
 
 def inspect_events(run_id, event_numbers, focus='all', save_to_dir=None, config_override=None):
-    """Show the pax event display for the events in dataset_number,
+    """Show the pax event display for the events in run_id,
 
     The dataframe must at least contain 'Basics'; currently only supports XENON100 run 10.
     focus can be 'all' (default) which shows the entire event, 'largest', 'first', 'main_s1', or 'main_s2'

--- a/hax/treemakers/common.py
+++ b/hax/treemakers/common.py
@@ -4,30 +4,28 @@ from hax.minitrees import TreeMaker
 from collections import defaultdict
 
 
-
-class Basics(TreeMaker):
+class Fundamentals(TreeMaker):
     """Simple minitree containing basic information about every event, regardless of its contents.
-    It is highly recommended you always use this.
+    This minitree is always loaded whether you like it or not :-)
 
     Provides:
+     - run_number: Run number of the run/dataset this event came from
      - event_number: Event number within the dataset
-     - dataset_number: Numerical representation of dataset id, e.g. xe100_120402_2000 -> 1204022000
      - event_time: Unix time (in ns since the unix epoch) of the start of the event window
      - event_duration: duration (in ns) of the event
-     - run_number: Run number of the run/dataset this event came from
     """
     __version__ = '0.1'
     branch_selection = ['event_number', 'start_time', 'stop_time']
 
     def extract_data(self, event):
-        return dict(event_number=event.event_number,
-                    run_number=self.run_number,
+        return dict(run_number=self.run_number,
+                    event_number=event.event_number,
                     event_time=event.start_time,
                     event_duration=event.stop_time - event.start_time)
 
 
-class MainInteraction(TreeMaker):
-    """Information on the main interaction of the event.
+class Basics(TreeMaker):
+    """Basic information needed in most (standard) analyses, mostly on the main interaction.
 
     Provides:
      - s1: The uncorrected area in pe of the main interaction's S1
@@ -58,14 +56,11 @@ class MainInteraction(TreeMaker):
 
     """
     __version__ = '0.1'
-    extra_branches = ['peaks.range_area_decile[11]',]
 
     def extract_data(self, event):
-        event_data = dict(event_number=event.event_number,
-                          run_number=self.run_number,
-                          event_time=event.start_time)
+        event_data = dict()
 
-        # Detect events without at least one S1 + S2 pair immediatly
+        # Detect events without at least one S1 + S2 pair immediately
         # We cannot even fill the basic variables for these
         if len(event.interactions) != 0:
 
@@ -117,7 +112,8 @@ class MainInteraction(TreeMaker):
 
 class LargestPeakProperties(TreeMaker):
     """Largest peak properties for each type and for all peaks.
-    If you're doing an S1-only or S2-only analysis, you'll want this info instead of MainInteraction.
+    If you're doing an S1-only or S2-only analysis, you'll want this info instead of Basics.
+    In other case you may want to combine this and Basics.
     """
     extra_branches = ['peaks.n_hits', 'peaks.hit_time_std', 'peaks.center_time',
                       'peaks.n_saturated_channels', 'peaks.n_contributing_channels']

--- a/hax/treemakers/common.py
+++ b/hax/treemakers/common.py
@@ -128,8 +128,7 @@ class LargestPeakProperties(TreeMaker):
                               'n_hits', 'hit_time_std', 'center_time',
                               'n_saturated_channels', 'n_contributing_channels']
 
-    @staticmethod
-    def get_properties(peak, prefix=''):
+    def get_properties(self, peak, prefix=''):
         """Return dictionary with peak properties, keys prefixed with prefix"""
         result = {field: getattr(peak, field) for field in self.peak_properties_to_get}
         result['range_50p_area'] = peak.range_area_decile[5]
@@ -148,13 +147,13 @@ class LargestPeakProperties(TreeMaker):
         for p_i, p in enumerate(peaks):
             if p.detector != 'tpc':
                 continue
-            for p_type in (p.type, 'any'):
+            for p_type in (p.type, 'largest'):
                 if p.area > largest_peak_per_type.get(p_type, (None, 0))[1]:
                     # New largest peak of this peak type
-                    largest_peak_per_type[p.type] = (p_i, p.area)
+                    largest_peak_per_type[p_type] = (p_i, p.area)
 
         result = {}
-        for p_type, p_index in largest_peak_per_type.items():
+        for p_type, (p_index, _) in largest_peak_per_type.items():
             result.update(self.get_properties(peaks[p_index], prefix=p_type + '_'))
 
         return result

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -1,0 +1,21 @@
+from hax.minitrees import TreeMaker
+
+
+class LargestTriggeringSignal(TreeMaker):
+    """Information on the largest trigger signal with the trigger flag set in the event
+
+    Provides:
+     - trigger_*, where * is any of the attributes of datastructure.TriggerSignal
+    """
+    extra_branches = ['trigger_signals*']
+    __version__ = '0.0.3'
+
+    def extract_data(self, event):
+        tss = [t for t in event.trigger_signals if t.trigger]
+        if not len(tss):
+            # No trigger signal! This indicates an error in the trigger's signal grouping,
+            # See https://github.com/XENON1T/pax/issues/344
+            return dict()
+        ts = tss[int(np.argmax([t.n_pulses for t in tss]))]
+        return {"trigger_" + k: getattr(ts, k)
+                for k in [a[0] for a in TriggerSignal.get_fields_data(TriggerSignal())]}

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -1,3 +1,5 @@
+import numpy as np
+from pax.datastructure import TriggerSignal
 from hax.minitrees import TreeMaker
 
 

--- a/hax/trigger_data.py
+++ b/hax/trigger_data.py
@@ -1,9 +1,11 @@
 import zipfile
 import zlib
+import os
 from collections import defaultdict
 
 import numpy as np
 import bson
+import pandas as pd
 
 from pax import datastructure
 
@@ -49,7 +51,7 @@ def get_trigger_data(run_id, select_data_types='all'):
 
         if isinstance(data[k][0], dict):
             # Dictionaries describing data
-            data[k] = pd.DataFrame(data['batch_info'])
+            data[k] = pd.DataFrame(data[k])
 
         elif k == 'trigger_signals':
             data[k] = np.concatenate(data[k])

--- a/hax/trigger_data.py
+++ b/hax/trigger_data.py
@@ -1,9 +1,13 @@
-import hax
 import zipfile
 import zlib
-import bson
 from collections import defaultdict
+
+import numpy as np
+import bson
+
 from pax import datastructure
+
+import hax
 
 # Custom data types used (others are just np.int)
 data_types = {

--- a/hax/trigger_data.py
+++ b/hax/trigger_data.py
@@ -1,0 +1,62 @@
+import hax
+import zipfile
+import zlib
+import bson
+from collections import defaultdict
+from pax import datastructure
+
+# Custom data types used (others are just np.int)
+data_types = {
+    'trigger_signals': datastructure.TriggerSignal.get_dtype(),
+    'trigger_signals_histogram': np.float,
+}
+matrix_fields = ['trigger_signals_histogram', 'count_of_2pmt_coincidences']
+
+
+def get_trigger_data(run_id, select_data_types='all'):
+    """Return dictionary with the trigger data from run_id
+    select_data_types can be 'all', a trigger data type name, or a list of trigger data type names.
+    If you want to find out which data types exists, use 'all' and look at the keys of the dictionary.
+    """
+    if isinstance(select_data_types, str) and select_data_types != 'all':
+        select_data_types = [select_data_types]
+
+    data = defaultdict(list)
+    run_name = hax.runs.get_run_name(run_id)
+    f = zipfile.ZipFile(os.path.join(hax.config['raw_data_local_path'],
+                                     run_name, 'trigger_monitor_data.zip'))
+    for doc_name in f.namelist():
+        data_type, index = doc_name.split('=')
+        if select_data_types != 'all':
+            if data_type not in select_data_types:
+                continue
+        with f.open(doc_name) as doc_file:
+            d = doc_file.read()
+            d = zlib.decompress(d)
+            d = bson.BSON.decode(d)
+            if 'data' in d:
+                d = np.fromstring(d['data'], dtype=data_types.get(data_type, np.int))
+            data[data_type].append(d)
+
+    # Flatten / post-process the data
+    for k in data.keys():
+        if not len(data[k]):
+            continue
+
+        if isinstance(data[k][0], dict):
+            # Dictionaries describing data
+            data[k] = pd.DataFrame(data['batch_info'])
+
+        elif k == 'trigger_signals':
+            data[k] = np.concatenate(data[k])
+
+        else:
+            data[k] = np.vstack(data[k])
+
+            if k in matrix_fields:
+                n = np.sqrt(data[k].shape[1]).astype('int')
+                data[k] = data[k].reshape((-1, n, n))
+
+    if select_data_types != 'all' and len(select_data_types) == 1:
+        return data[select_data_types[0]]
+    return data


### PR DESCRIPTION
~~This splits the Basics treemaker into two: Basics and MainInteraction. Basics now contains a 'bare minimum' of information: the event time, duration, and run number. It loads really really fast. MainInteraction contains everything else, and now includes also the s1 and s2 width (range_area_decile[5]).~~

~~Both Basics and MainInteraction are loaded by default if you just call hax.minitrees.load, but if you did this: hax.minitrees.load(run_number, ['Basics', MyTreemaker]) and use the main interaction properties, you have to change it to: hax.minitrees.load(run_number, ['Basics', 'MainInteraction', MyTreemaker])~~

Please see the posts below for an updated description.

The main reason for this change is that not all analyses need the full main interaction info (e.g. LargestPeakProperties analyses, analysis on trigger signals, ...), but you always need the event number and run number to inspect events. 

This also fixes the LargestPeakProperties treemaker and a small bug with inspect_events_from_minitree.