### PR TITLE
Parallel minitrees, preselections, and out-of-core computations

### DIFF
--- a/examples/Preselections and out-of-core computation.ipynb
+++ b/examples/Preselections and out-of-core computation.ipynb
@@ -1,0 +1,1009 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Preselections and out-of-core computations with hax"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Jelle, 7 October 2016"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/project/lgrandi/anaconda3/envs/pax_head/lib/python3.4/site-packages/IPython/kernel/__init__.py:13: ShimWarning: The `IPython.kernel` package has been deprecated. You should import from ipykernel or jupyter_client instead.\n",
+      "  \"You should import from ipykernel or jupyter_client instead.\", ShimWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "logging.basicConfig(level=logging.INFO)\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from tqdm import tqdm\n",
+    "import dask\n",
+    "\n",
+    "import matplotlib\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from pax.configuration import load_configuration\n",
+    "pax_config = load_configuration('XENON1T')\n",
+    "\n",
+    "import hax\n",
+    "from hax import cuts\n",
+    "# Load minitrees from several analysts kind enough to share their home directory\n",
+    "# If you think this is getting crazy, I agree... the solution is a common minitree folder\n",
+    "# with pre-made basics minitrees. But that would require someone maintaining it.\n",
+    "hax.init(minitree_paths=['.', \n",
+    "                         '/home/aalbers/minitrees', \n",
+    "                         '/home/breur/minitrees/v5.6.2', \n",
+    "                         '/home/alecstein/projects/minitrees'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's select run numbers for about 8 days of background data. This selection is similar to the one used by Fei and Sander for their low-energy background notes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "time_range = [pd.to_datetime('09/21/2016'), pd.to_datetime('10/01/2016')]\n",
+    "query = ('source__type == \"none\"   &'                          # Background\n",
+    "         'tags == \"\" & location != \"\"   &'                     # Nothing weird,\n",
+    "         'start > @time_range[0] & end < @time_range[1]')      # In the time range\n",
+    "run_numbers = hax.runs.datasets.query(query, local_dict=dict(time_range=time_range)).number.values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total lifetime: 7 days 20:03:04\n"
+     ]
+    }
+   ],
+   "source": [
+    "dsets = hax.runs.datasets[np.in1d(hax.runs.datasets.number, run_numbers)]\n",
+    "livetime = (dsets.end - dsets.start).sum()\n",
+    "print(\"Total lifetime: %s\" % livetime)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Trying to load this the usual way:\n",
+    "    \n",
+    "    data = hax.minitrees.load(run_numbers)\n",
+    "    \n",
+    "is possible, but takes a minute or more and 2 GB of RAM.\n",
+    "    \n",
+    "Clearly this will not scale to using even larger datasets (several weeks of bg data, or some high-rate calibration data) or more complicated analysis using more variables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Preselections"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Often you're interested in a small part of the data, e.g. the low-energy events. You can then use the preselection option:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/project/lgrandi/anaconda3/envs/pax_head/lib/python3.4/site-packages/pandas/computation/align.py:98: RuntimeWarning: divide by zero encountered in log10\n",
+      "  ordm = np.log10(abs(reindexer_size - term_axis_size))\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cs1 < 200 selection: 3660207 rows removed (1.58% passed)\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = hax.minitrees.load(run_numbers, preselection='cs1 < 200', num_workers=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This combines particularly well with parallel minitree loading (as shown above), since the preselection can then be applied separately on each run, i.e. \"out of core\". \n",
+    "\n",
+    "Note that 'cs1' is just a variable defined by the basic treemaker; you can use any other variable defined by a treemarker you're loading in. So if you have more complicated preselection cuts, use a treemaker to output a cut boolean (or p-value, or whatever you want to cut on) and use that in the preselection string. The preselection is evaluated for every run after merging the dataframes for different treemakers.\n",
+    "\n",
+    "The cut history of your preselection is kept, as if you did a normal cut."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>selection_desc</th>\n",
+       "      <th>n_before</th>\n",
+       "      <th>n_after</th>\n",
+       "      <th>n_removed</th>\n",
+       "      <th>fraction_passed</th>\n",
+       "      <th>cumulative_fraction_left</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>cs1 &lt; 200</td>\n",
+       "      <td>3719091</td>\n",
+       "      <td>58884</td>\n",
+       "      <td>3660207</td>\n",
+       "      <td>0.015833</td>\n",
+       "      <td>0.015833</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  selection_desc  n_before  n_after  n_removed  fraction_passed  \\\n",
+       "0      cs1 < 200   3719091    58884    3660207         0.015833   \n",
+       "\n",
+       "   cumulative_fraction_left  \n",
+       "0                  0.015833  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cuts.history(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>selection_desc</th>\n",
+       "      <th>n_before</th>\n",
+       "      <th>n_after</th>\n",
+       "      <th>n_removed</th>\n",
+       "      <th>fraction_passed</th>\n",
+       "      <th>cumulative_fraction_left</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>cs1 &lt; 200</td>\n",
+       "      <td>3719091</td>\n",
+       "      <td>58884</td>\n",
+       "      <td>3660207</td>\n",
+       "      <td>0.015833</td>\n",
+       "      <td>0.015833</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>x above 10</td>\n",
+       "      <td>265028</td>\n",
+       "      <td>81585</td>\n",
+       "      <td>183443</td>\n",
+       "      <td>0.307835</td>\n",
+       "      <td>0.021937</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  selection_desc  n_before  n_after  n_removed  fraction_passed  \\\n",
+       "0      cs1 < 200   3719091    58884    3660207         0.015833   \n",
+       "1     x above 10    265028    81585     183443         0.307835   \n",
+       "\n",
+       "   cumulative_fraction_left  \n",
+       "0                  0.015833  \n",
+       "1                  0.021937  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = cuts.above(data, 'x', 10)\n",
+    "cuts.history(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/project/lgrandi/anaconda3/envs/pax_head/lib/python3.4/site-packages/pandas/computation/align.py:98: RuntimeWarning: divide by zero encountered in log10\n",
+      "  ordm = np.log10(abs(reindexer_size - term_axis_size))\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = hax.minitrees.load(run_numbers, preselection=['cs1 > 0'],\n",
+    "                          delayed=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you apply multiple preselections, it is recommended to use a list of strings rather than '&'-ing the conditions together. This way we can separate the passthrough info."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/project/lgrandi/anaconda3/envs/pax_head/lib/python3.4/site-packages/pandas/computation/align.py:98: RuntimeWarning: divide by zero encountered in log10\n",
+      "  ordm = np.log10(abs(reindexer_size - term_axis_size))\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cs1 < 200 selection: 3727110 rows removed (1.56% passed)\n",
+      "x**2 + y**2 < 20**2 selection: 233553 rows removed (8.82% passed)\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = hax.minitrees.load(run_numbers, \n",
+    "                          preselection=['cs1 < 200', 'x**2 + y**2 < 20**2'],\n",
+    "                          num_workers=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>selection_desc</th>\n",
+       "      <th>n_before</th>\n",
+       "      <th>n_after</th>\n",
+       "      <th>n_removed</th>\n",
+       "      <th>fraction_passed</th>\n",
+       "      <th>cumulative_fraction_left</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>cs1 &lt; 200</td>\n",
+       "      <td>3785998</td>\n",
+       "      <td>58888</td>\n",
+       "      <td>3727110</td>\n",
+       "      <td>0.015554</td>\n",
+       "      <td>0.015554</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>x**2 + y**2 &lt; 20**2</td>\n",
+       "      <td>256151</td>\n",
+       "      <td>22598</td>\n",
+       "      <td>233553</td>\n",
+       "      <td>0.088221</td>\n",
+       "      <td>0.005969</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        selection_desc  n_before  n_after  n_removed  fraction_passed  \\\n",
+       "0            cs1 < 200   3785998    58888    3727110         0.015554   \n",
+       "1  x**2 + y**2 < 20**2    256151    22598     233553         0.088221   \n",
+       "\n",
+       "   cumulative_fraction_left  \n",
+       "0                  0.015554  \n",
+       "1                  0.005969  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cuts.history(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_number</th>\n",
+       "      <th>event_number</th>\n",
+       "      <th>cs1</th>\n",
+       "      <th>cs2</th>\n",
+       "      <th>drift_time</th>\n",
+       "      <th>largest_coincidence</th>\n",
+       "      <th>largest_other_s1</th>\n",
+       "      <th>largest_other_s2</th>\n",
+       "      <th>largest_unknown</th>\n",
+       "      <th>largest_veto</th>\n",
+       "      <th>...</th>\n",
+       "      <th>s1_area_fraction_top</th>\n",
+       "      <th>s1_range_50p_area</th>\n",
+       "      <th>s2</th>\n",
+       "      <th>s2_area_fraction_top</th>\n",
+       "      <th>s2_range_50p_area</th>\n",
+       "      <th>x</th>\n",
+       "      <th>y</th>\n",
+       "      <th>z</th>\n",
+       "      <th>event_duration</th>\n",
+       "      <th>event_time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>336</th>\n",
+       "      <td>3014</td>\n",
+       "      <td>336</td>\n",
+       "      <td>131.193485</td>\n",
+       "      <td>192877.172274</td>\n",
+       "      <td>1150.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1304.783691</td>\n",
+       "      <td>13.162566</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.325104</td>\n",
+       "      <td>57.897387</td>\n",
+       "      <td>192127.453125</td>\n",
+       "      <td>0.551483</td>\n",
+       "      <td>261.008343</td>\n",
+       "      <td>13.092105</td>\n",
+       "      <td>-13.840225</td>\n",
+       "      <td>-0.17020</td>\n",
+       "      <td>2650140</td>\n",
+       "      <td>1474505513654728430</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>832</th>\n",
+       "      <td>3014</td>\n",
+       "      <td>832</td>\n",
+       "      <td>70.982268</td>\n",
+       "      <td>78683.997440</td>\n",
+       "      <td>1090.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>8.007159</td>\n",
+       "      <td>741.755005</td>\n",
+       "      <td>14.234510</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.351792</td>\n",
+       "      <td>48.172087</td>\n",
+       "      <td>78394.078125</td>\n",
+       "      <td>0.571569</td>\n",
+       "      <td>181.780709</td>\n",
+       "      <td>-15.336466</td>\n",
+       "      <td>-3.865288</td>\n",
+       "      <td>-0.16132</td>\n",
+       "      <td>2385890</td>\n",
+       "      <td>1474505576503544370</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1571</th>\n",
+       "      <td>3014</td>\n",
+       "      <td>1571</td>\n",
+       "      <td>97.317671</td>\n",
+       "      <td>656003.589052</td>\n",
+       "      <td>5350.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>160894.843750</td>\n",
+       "      <td>18.078890</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.762105</td>\n",
+       "      <td>17.281575</td>\n",
+       "      <td>644225.062500</td>\n",
+       "      <td>0.480113</td>\n",
+       "      <td>396.418828</td>\n",
+       "      <td>-13.590852</td>\n",
+       "      <td>13.092105</td>\n",
+       "      <td>-0.79180</td>\n",
+       "      <td>4887090</td>\n",
+       "      <td>1474505666073927260</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1599</th>\n",
+       "      <td>3014</td>\n",
+       "      <td>1599</td>\n",
+       "      <td>8.692314</td>\n",
+       "      <td>92.760054</td>\n",
+       "      <td>36910.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>31204.626953</td>\n",
+       "      <td>14.676259</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.126685</td>\n",
+       "      <td>12.438091</td>\n",
+       "      <td>81.860634</td>\n",
+       "      <td>0.669333</td>\n",
+       "      <td>907.345139</td>\n",
+       "      <td>18.328947</td>\n",
+       "      <td>-2.369048</td>\n",
+       "      <td>-5.46268</td>\n",
+       "      <td>2230510</td>\n",
+       "      <td>1474505669366812070</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1838</th>\n",
+       "      <td>3014</td>\n",
+       "      <td>1838</td>\n",
+       "      <td>9.249316</td>\n",
+       "      <td>192.272268</td>\n",
+       "      <td>22250.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>128323.656250</td>\n",
+       "      <td>14.134089</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>13.252068</td>\n",
+       "      <td>178.316742</td>\n",
+       "      <td>0.585296</td>\n",
+       "      <td>1413.922676</td>\n",
+       "      <td>9.850250</td>\n",
+       "      <td>0.124687</td>\n",
+       "      <td>-3.29300</td>\n",
+       "      <td>2395870</td>\n",
+       "      <td>1474505698486137350</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 21 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      run_number  event_number         cs1            cs2  drift_time  \\\n",
+       "336         3014           336  131.193485  192877.172274      1150.0   \n",
+       "832         3014           832   70.982268   78683.997440      1090.0   \n",
+       "1571        3014          1571   97.317671  656003.589052      5350.0   \n",
+       "1599        3014          1599    8.692314      92.760054     36910.0   \n",
+       "1838        3014          1838    9.249316     192.272268     22250.0   \n",
+       "\n",
+       "      largest_coincidence  largest_other_s1  largest_other_s2  \\\n",
+       "336                   0.0          0.000000       1304.783691   \n",
+       "832                   0.0          8.007159        741.755005   \n",
+       "1571                  0.0          0.000000     160894.843750   \n",
+       "1599                  0.0          0.000000      31204.626953   \n",
+       "1838                  0.0          0.000000     128323.656250   \n",
+       "\n",
+       "      largest_unknown  largest_veto         ...           \\\n",
+       "336         13.162566           0.0         ...            \n",
+       "832         14.234510           0.0         ...            \n",
+       "1571        18.078890           0.0         ...            \n",
+       "1599        14.676259           0.0         ...            \n",
+       "1838        14.134089           0.0         ...            \n",
+       "\n",
+       "      s1_area_fraction_top  s1_range_50p_area             s2  \\\n",
+       "336               0.325104          57.897387  192127.453125   \n",
+       "832               0.351792          48.172087   78394.078125   \n",
+       "1571              0.762105          17.281575  644225.062500   \n",
+       "1599              0.126685          12.438091      81.860634   \n",
+       "1838              0.000000          13.252068     178.316742   \n",
+       "\n",
+       "      s2_area_fraction_top  s2_range_50p_area          x          y        z  \\\n",
+       "336               0.551483         261.008343  13.092105 -13.840225 -0.17020   \n",
+       "832               0.571569         181.780709 -15.336466  -3.865288 -0.16132   \n",
+       "1571              0.480113         396.418828 -13.590852  13.092105 -0.79180   \n",
+       "1599              0.669333         907.345139  18.328947  -2.369048 -5.46268   \n",
+       "1838              0.585296        1413.922676   9.850250   0.124687 -3.29300   \n",
+       "\n",
+       "      event_duration           event_time  \n",
+       "336          2650140  1474505513654728430  \n",
+       "832          2385890  1474505576503544370  \n",
+       "1571         4887090  1474505666073927260  \n",
+       "1599         2230510  1474505669366812070  \n",
+       "1838         2395870  1474505698486137350  \n",
+       "\n",
+       "[5 rows x 21 columns]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Out-of-core computation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What if you want to e.g. make a cs1/cs2 spectrum of all events? You can't use preselections to make the data fit into RAM. You could write a for loop over datasets, adding to the histogram on each pass, but that's tedius, and you'd have to write your own parallelization code to get it fast. Instead, try the delayed option:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/project/lgrandi/anaconda3/envs/pax_head/lib/python3.4/site-packages/pandas/computation/align.py:98: RuntimeWarning: divide by zero encountered in log10\n",
+      "  ordm = np.log10(abs(reindexer_size - term_axis_size))\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = hax.minitrees.load(run_numbers, delayed=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice very little seems to have actually happened. Under the hood it loaded one minitree (to known which columns to expected), but for the others it created \"delayed objects\" and put some interface over them to make them behave like a dataframe -- a Dask dataframe.\n",
+    "\n",
+    "You can make the delayed objects real and force the data to a real pandas Dataframe using\n",
+    "\n",
+    "    data.compute()\n",
+    "\n",
+    "(of course this eats your RAM, as discussed above).\n",
+    "\n",
+    "You can manipulate the Dask dataframe with the pandas API and/or the hax.cuts functions:  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "data['r'] = (data.x**2 + data.y**2)**0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = cuts.below(data, 'r', 40)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can call .head() to figure out if your aliases / cuts have worked (this will only require loading one minitree)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/project/lgrandi/anaconda3/envs/pax_head/lib/python3.4/site-packages/pandas/computation/align.py:98: RuntimeWarning: divide by zero encountered in log10\n",
+      "  ordm = np.log10(abs(reindexer_size - term_axis_size))\n",
+      "/project/lgrandi/anaconda3/envs/pax_head/lib/python3.4/site-packages/pandas/core/ops.py:716: RuntimeWarning: invalid value encountered in less\n",
+      "  result = getattr(x, name)(y)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run_number</th>\n",
+       "      <th>event_number</th>\n",
+       "      <th>cs1</th>\n",
+       "      <th>cs2</th>\n",
+       "      <th>drift_time</th>\n",
+       "      <th>largest_coincidence</th>\n",
+       "      <th>largest_other_s1</th>\n",
+       "      <th>largest_other_s2</th>\n",
+       "      <th>largest_unknown</th>\n",
+       "      <th>largest_veto</th>\n",
+       "      <th>...</th>\n",
+       "      <th>s1_range_50p_area</th>\n",
+       "      <th>s2</th>\n",
+       "      <th>s2_area_fraction_top</th>\n",
+       "      <th>s2_range_50p_area</th>\n",
+       "      <th>x</th>\n",
+       "      <th>y</th>\n",
+       "      <th>z</th>\n",
+       "      <th>event_duration</th>\n",
+       "      <th>event_time</th>\n",
+       "      <th>r</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3014</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1137.244685</td>\n",
+       "      <td>2.280715e+05</td>\n",
+       "      <td>2730.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>313.682861</td>\n",
+       "      <td>1153.935425</td>\n",
+       "      <td>13.876470</td>\n",
+       "      <td>11.763616</td>\n",
+       "      <td>...</td>\n",
+       "      <td>59.042145</td>\n",
+       "      <td>225972.578125</td>\n",
+       "      <td>0.540047</td>\n",
+       "      <td>365.819230</td>\n",
+       "      <td>3.117168</td>\n",
+       "      <td>34.787594</td>\n",
+       "      <td>-0.40404</td>\n",
+       "      <td>2665940</td>\n",
+       "      <td>1474505474267462760</td>\n",
+       "      <td>34.926973</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3014</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1107.570484</td>\n",
+       "      <td>1.997143e+05</td>\n",
+       "      <td>42420.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1063.926147</td>\n",
+       "      <td>14.448113</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>64.791784</td>\n",
+       "      <td>172989.312500</td>\n",
+       "      <td>0.584117</td>\n",
+       "      <td>499.668401</td>\n",
+       "      <td>9.351503</td>\n",
+       "      <td>-38.029449</td>\n",
+       "      <td>-6.27816</td>\n",
+       "      <td>2563120</td>\n",
+       "      <td>1474505474367625930</td>\n",
+       "      <td>39.162350</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>3014</td>\n",
+       "      <td>4</td>\n",
+       "      <td>7804.560521</td>\n",
+       "      <td>1.173481e+06</td>\n",
+       "      <td>160920.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>7.837758</td>\n",
+       "      <td>370317.968750</td>\n",
+       "      <td>15.635055</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>66.532937</td>\n",
+       "      <td>680456.875000</td>\n",
+       "      <td>0.547282</td>\n",
+       "      <td>1073.627208</td>\n",
+       "      <td>-0.374060</td>\n",
+       "      <td>-36.283836</td>\n",
+       "      <td>-23.81616</td>\n",
+       "      <td>3753160</td>\n",
+       "      <td>1474505474381265020</td>\n",
+       "      <td>36.285764</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>3014</td>\n",
+       "      <td>8</td>\n",
+       "      <td>4371.209123</td>\n",
+       "      <td>4.666071e+05</td>\n",
+       "      <td>3790.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>315247.375000</td>\n",
+       "      <td>13.740943</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>68.666057</td>\n",
+       "      <td>460656.468750</td>\n",
+       "      <td>0.477846</td>\n",
+       "      <td>337.214364</td>\n",
+       "      <td>17.082081</td>\n",
+       "      <td>26.807644</td>\n",
+       "      <td>-0.56092</td>\n",
+       "      <td>2739370</td>\n",
+       "      <td>1474505474747732310</td>\n",
+       "      <td>31.787533</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>3014</td>\n",
+       "      <td>10</td>\n",
+       "      <td>2778.598442</td>\n",
+       "      <td>2.133712e+05</td>\n",
+       "      <td>14180.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>154586.984375</td>\n",
+       "      <td>14.301223</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>...</td>\n",
+       "      <td>63.699937</td>\n",
+       "      <td>203366.921875</td>\n",
+       "      <td>0.545507</td>\n",
+       "      <td>371.254950</td>\n",
+       "      <td>-35.785088</td>\n",
+       "      <td>6.359023</td>\n",
+       "      <td>-2.09864</td>\n",
+       "      <td>4144590</td>\n",
+       "      <td>1474505474830371070</td>\n",
+       "      <td>36.345697</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 22 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    run_number  event_number          cs1           cs2  drift_time  \\\n",
+       "2         3014             2  1137.244685  2.280715e+05      2730.0   \n",
+       "3         3014             3  1107.570484  1.997143e+05     42420.0   \n",
+       "4         3014             4  7804.560521  1.173481e+06    160920.0   \n",
+       "8         3014             8  4371.209123  4.666071e+05      3790.0   \n",
+       "10        3014            10  2778.598442  2.133712e+05     14180.0   \n",
+       "\n",
+       "    largest_coincidence  largest_other_s1  largest_other_s2  largest_unknown  \\\n",
+       "2                   0.0        313.682861       1153.935425        13.876470   \n",
+       "3                   0.0          0.000000       1063.926147        14.448113   \n",
+       "4                   0.0          7.837758     370317.968750        15.635055   \n",
+       "8                   0.0          0.000000     315247.375000        13.740943   \n",
+       "10                  0.0          0.000000     154586.984375        14.301223   \n",
+       "\n",
+       "    largest_veto    ...      s1_range_50p_area             s2  \\\n",
+       "2      11.763616    ...              59.042145  225972.578125   \n",
+       "3       0.000000    ...              64.791784  172989.312500   \n",
+       "4       0.000000    ...              66.532937  680456.875000   \n",
+       "8       0.000000    ...              68.666057  460656.468750   \n",
+       "10      0.000000    ...              63.699937  203366.921875   \n",
+       "\n",
+       "    s2_area_fraction_top  s2_range_50p_area          x          y         z  \\\n",
+       "2               0.540047         365.819230   3.117168  34.787594  -0.40404   \n",
+       "3               0.584117         499.668401   9.351503 -38.029449  -6.27816   \n",
+       "4               0.547282        1073.627208  -0.374060 -36.283836 -23.81616   \n",
+       "8               0.477846         337.214364  17.082081  26.807644  -0.56092   \n",
+       "10              0.545507         371.254950 -35.785088   6.359023  -2.09864   \n",
+       "\n",
+       "    event_duration           event_time          r  \n",
+       "2          2665940  1474505474267462760  34.926973  \n",
+       "3          2563120  1474505474367625930  39.162350  \n",
+       "4          3753160  1474505474381265020  36.285764  \n",
+       "8          2739370  1474505474747732310  31.787533  \n",
+       "10         4144590  1474505474830371070  36.345697  \n",
+       "\n",
+       "[5 rows x 22 columns]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can't make a scatterplot (except by using special software such as [datashader](https://github.com/bokeh/datashader). Histograms using plt.hist or plt.scatter also don't work... but you can create histograms with the multihist package:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from multihist import Histdd\n",
+    "mh = Histdd(data,\n",
+    "            dimensions=[('cs1', np.logspace(0, 5, 250)),\n",
+    "                        ('cs2', np.logspace(1, 7, 250))],\n",
+    "            compute_options=dict(num_workers=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This did several things for you behind the scenes: loading minitrees, applying your aliases and cuts, histogramming the data, and only then summing the histograms for each minitree. This makes sure you can make big histograms without frying your ram. \n",
+    "\n",
+    "Here's the result... who can identify all the populations? Enjoy ;-)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAy4AAAK3CAYAAABjrRuUAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzsvX+wHeV55/ltdHUv9wrpCkkjgRacA1IA44iAxKxtYlya\ncmKC47BMJrVBmexq8E7tOGFmN6oiVbuJd2WydmZrhol2U4PXmfIaa8rJ9aQySYp4+DFxKorj9a9B\nisKN+RVhTgwRCEtCAnEvukju/aPfp99vdz+nu885ffr0Oef5VN3qvk+//b5v/zz9vs+vIAxDGIZh\nGIZhGIZhNJlLht0BwzAMwzAMwzCMImzgYhiGYRiGYRhG47GBi2EYhmEYhmEYjccGLoZhGIZhGIZh\nNB4buBiGYRiGYRiG0Xhs4GIYhmEYhmEYRuOxgYthGIZhGIZhGI3HBi6GYRiGYRiGYTQeG7gYhmEY\nhmEYhtF4bOBiGIZhGIZhGEbjsYGLYRiGYRiGYRiNZ2wGLkEQXBcEwV8GQXDELZeCILhr2P0yDMMw\nDMMwDKN/gjAMh92HygmCYA2AFwH8UBiGy8Puj2EYhmEYhmEY/TE2GpcUdwH4Uxu0GIZhGIZhGMZ4\nMK4Dl/8WwH8YdicMwzAMwzAMw6iGRgxcgiC4PQiCR4Ig+LsgCH6g+aYEQXBfEAQvBkGwHATBN4Mg\n+Psd6loL4P0AHh10vw3DMAzDMAzDqIdGDFwArAFwFMAvAcg43QRB8HMA/g2A/QBuAfBXAJ4IgmCT\nUtd/A+A/h2G4MrjuGoZhGIZhGIZRJ41zzg+C4AcA7g7D8BGSfRPAt8Iw/J/d/wGAlwD8VhiG/yq1\n/yMAfjsMw/+U08ZGAHcAaAN4u/KDMAzDMAzDMPrlUgAtAE+EYXhqyH3JEATBuwBok+h1cDIMw+8N\nqe2hMTXsDhQRBMFqALsA/IbIwjAMgyD4CiKTMC67DsDfB/AzBdXeAeB3Ku6qYRiGYRiGUT3/GMDv\nDrsTTBAE71oN/O07w+vCUhAE7560wUvjBy6IRrKrAJxIyU8AuJ4FYRi+AeDKEnW2AeCLX/wi3v3u\nd1fQxerYt28fDhw40Kh6u923bPmicnnbu902qPPaL3a9y223612+3l27jie2HT68tYt9fzu17z/L\nLV+23m63d9oW9e9xAD+ZkH/wg8+WPq/a+Ukft8bhw/+s1Plh+r3eu25zK+e5z38M7Rxk+/fT0WKG\nrv95f/7y+s71lDm36eui9+X/APC/xfdj2Taa/Hyn74du7sNumOT3+TPPPINf+IVfANx3W8PY9A6i\nmfK6VS4nAfwBMOeatoHLBPA2ALz73e/Gzp07h92XBPPz8wPpUz/1drtv2fJF5b761Vexa9cfAwDC\ncH/pfbVtgzqv/WLXu9z2YV3vIHgg8X/6PuyWfvqV15dkvRsS5XbubBX2SZ4zIDnI0fqaLA8Ae6lP\nrUS5Xq53dJzRsy/H6I99KyLLkWQ/v/rVQ6k+Za+Vr2NvQh6dn/zBHQBXf/b8pK9LkuRxZPuS108A\ns7KNr+lhaOcg278fiRaXtEjmz5+ce70vvp75+VdyjzPaJ3ldorrTfVkL4Efofsy2odHs93nyGuQd\nR5ogaCf+52cnTd7x5t1LRft221Y35ap8nzsaa9a/CWXeIEZVjMLA5SSAiwC2pORbALxaf3cGy549\nexpXb7f7li1fXG5HT/sO6hwOArve5bbb9S5fb94HUKd9//iPn6f98wdn6fJl+tT99s7PvmzLDmrK\ncjD1//7CYy76OOxM3nGUYPkBhOF+BAEL9+J3f/e6xPnLPQfLbb8+ux+4cB0wlX9t+BgXFhYKuxmG\n+7GwcF3qPkyep4WF/wF79rS6bqPJz3f2GIvPVS/Y+7zZTKG+j+m/ArCIBo/iamCUnfO/h8g5/1/3\n0MZOAIcPHz7ckFkbQ6P3j4Usd911Fx555JHigsZYUNX1LqtxqVozk1c3t1G+f+1UuVbHNnI1AGq7\nusalE/kz9x00DsvZfZLlfxfAz5evV9nedZ9z+pZlb+r/9OApp77Z/cnBR14duW0CmG359YJ+F90H\nZcpV8Rxo9aWf70E+f/2Q/1y11X36eYaS9VR/XYZxno8cOYJdu3YBwK4wDI8MvMEukG/JX0L9Gpfj\nAD4TrTbuvAyaRmhcgiBYA2A7AJlXujYIgh8FcDoMw5cA/CaALwRBcBjAtwHsQ2Tb94V+2t23bx/m\n5+exZ8+ekRzljztN+fExJpem3YOD6k+39Q7yvMQDjblybYfhftx112E88oiXax92/fQ5d/Azux/h\nUrZdv0+7u8a4PjkHsy1qI78+7fzJvkL3WiqQ2Vq2PqN7eIDS9T2SqSs7iTHqLCwsYGFhAWfPnh12\nVwqZArB6CG1OKk059lsB/BmiHC4hopwtQDSl9LEwDH/P5Wz5dUQmYkcB3BGG4ff7afTAgQOmcZkQ\nbGA6Wdj1nizsek8Wdr3HH5lQJo2LYQBoyMAlDMM/R0EyzDAMP4NYM2YY3WE/dJOFXe/B0o3p2eD7\nErX18z//QO9mX9C1Kv1oaToFAxgm/c7s+3qGO7s/Sc93GfOsYV8Pw6iTRgxcDMMwRpk6TKf6abdb\nh/1e2qi8zuXe7emHZVKnm5QdVLaXrDNxDqSc7tuSqUfdN5/yfemjni4pU1fTTDqFQT2fXG/ZgXYV\n56ip53nYrEL9H9Oram6vSdjAxTCMBE11dO2VcTmeqo6jaufp/vqQdeyvYva4jmNk7UXZvmvbNS2I\n9iHbyeenDN1qf3yfigIA9NqPiFF9Fg3DGB4TPXAx53zDMIzuKZohrsqcZZxm2/XjL2lGNst1yT75\ng4pO2p9IPiQtmtE9s/nndVzPuznnF7c5qUzysZtzvmEYhmEYRsMw53yjExM9cDEMY3RogomTUY7q\nHNzbVE9LrV/aqMNBuVP+mqKyddyvQfBAcna+g0+K9EsL19yPL9SgSJ/HSTE3i4+zQONiGJOGDVwM\nw0gwbh8C43I8VR3HsM5H9+32F42rU3udHJu752Cmjbx8L0XHn9xnf6q+dqLdiL2KTKcoCWe2fCvR\nj05UFaXMyCEzAB2P99k4Yc759WIDF8MwjAmk7Mx1Ubk6NQudPrzLfJAX9VP7CM9L4thpv05ai140\nBXWHVM7P9J7vo1N0DfLOeT+anrQGadzpdLyTookyDBu4GIYxEtgP8egwmCz11Tvq52a3V010yg0g\nqr9XD1JfvSzDcju3Fr1f/UQO62ff3s5ldRqzZmP5WkYHc86vl0k+dosqZhiGYRiG0TBGKaqYUS8T\nPXCxqGKji6nFjVFi3AIL9OLb0Ck3SNnz0U2bZWemB2GKVdZ0aRRmz0ehj8OgXvPIdh/7ju7v5ChF\nFTMfl3qZ6IGLYRjGpFLdR8zegUSjSpoEtXO391JnEjbFcoOY5XbmuLTjzIt2lqTYmT7TP8VcTTUh\nUn1xymZtL++4nxe9rYxPTNUfzqP0IV4Ng3nWDGOUsIGLMTRGeTbIMMaRfp7J4hDFnbUa/exbFZr2\nJR0qWI/uVeSPUE3fux0IaFqBfjUFeYOburQQ3QSLyCtXNf2Ele7n3I2yVsy+AYxesIGLMZLYC84Y\nJUb5ftX63tusb/6HftG+3WR8L1t/Xnb5Xkx0irQX6TDDhW10yMWSqbdDxLNu0K+z7gg/DO3KpNLN\ns5YXyMAYHOacXy+XDLsDhmEYhmEYhmEYRUzyoM0wDGMkGZaz/7CDDOQ5+Hcy48ovp89oR8fZvYlX\nkdlOkYalV0fsXq5LnRnph2W+1St1nYuikMf9mI0N+poaninU/zE9yR/vk3zsFg55yNhL1DCaRRX5\nV3qpr599q0A3iUoPfvZnZOX6mGd6xvVpAyUn29HyosVh+TR0HsgN61r1sn1QfejHab6bAAlV7jts\n8q6VhUM2OjHRAxcLhzwYmjjL08Q+Gca4U+x038wM8mUpH/q4PdD2B1l31VqBvLq0+oat5cujqt+V\nsvdHk89F1YxSOGSjXiZ64GIYhjGaDOcDfvgfS6K9yG5Jznjn9VPTpHA9nR3nu8nanq1H067kh7eN\n9y3UspS9H8ppTXRn+1bHbUUM/77pjkH2N7/uasMdj9p5H1XMOb9ezDnfMAzDMAzDMIzGM8mDNsMw\njL5okulGvdm8qzEB663tti6/if5ZlDLlfFLK9n0U/Ai0PhYHBaguP4ueDHMyKGs6WGVbdbVndMY0\nLvUyycduDIgmvkSb2CfD6JVRyZ5dvdN9/yZy5dvPNykrT3/5awAAO1LmbE91GmwURVvjbS0A3Q/G\nqn6XNsHZvle6MR3Mr6fVVXujMIA2jEFhAxdjaFQ9QzuITNGGMYqU9b/opa46tTldhfbdUa+Wqb+6\n2vH6IAeheZqWKkIvA8rgaLbVU73pupvyvq6iT71q9Po5B3VqfyadVaj/Y3pVze01CRu4GIZh9EiT\nPgqGPRtbh0NzbA62qBSKzcNknxbKakn0vrN2p3NemOJ6KiDjnL9fj/Y1R7LltlpVGLZSg5a9iW1A\nn/fQcntkNIJVMuyQ0FVpfwyj6Uz0wMXyuBiGYRiGYTQLy+NidGKiBy6Wx2X0KKu2txknw6iPTmYp\nw86flDaHirQN1QUWkPor0VR0Qcd2Z8vkxGlX3JcHUNb3aNj3Q1Op4r4Zt9+8UcrjYs759TLJx24M\nmUE6eTbRVtowhkG/93+TzFLCp2RNS4rYrrYtJS9Mb230E1BAM+PK6cPyA2QyKEItf0x+fXn3jH7t\nD1bynm3iu7ruPlXVXhPPpWFUgQ1cjJHFBiejSxNnXgfZp65Dyjbo/HTTl6JBTLcOw2Wc2H2bvQ0Q\nOvW5SdcA0I+zl9DHZesrE5GsXP3VMOz3fS/3Q/XnoE3ttyqt2+gdc86vFxu4GCNFWQfkYX9kGMaw\nGNYMcadnstugAXmZ6/PJhi/WPu760cwWfSzqx6ppI7ivee1qQQH0QAERRQEFdJlmLleGXu61SX03\nl9ViDaJ+wxgnLhl2BwzDMAzDMAzDMIowjYvRE3kzlU0zsTAMw1OkGRkGXee5KOGE3k29/ZDUDOna\nEMkmr2WSH7YJVCfKaLya2vdxwM7t6GDO+fUyycdujDD2Ih9tmnj96shDMqjyg6RsX5ImWO2e6/Hl\nW+UKzu5HuDSIIAHVONX3k5Ax35+onSrbSm3vru5O1898KSKa8EzatTAMG7gYhtEQhpFduqo+DYum\n96+IQUYk6+x03y7YL397t+W6IR3muNt2++lT8nzlOeyXC8BQZvtgNGD1aSp6DVzRa796SQcwau+E\nUcSc8+vFBi5GTwza0dAwjMFQx/PZy8xwuX65D2olO3v14dCzzv7F5bLhhjV0J/7uNTz551nqy3Pm\n70R5h/1ufgv6GaiO4u9Kt4EptH0Nw0gy0QOXffv2YX5+Pk50ZBiGYRiGYQyXhYUFLCws4OzZs8Pu\nitEwJnrgcuDAAezcuXPY3TCIUTd9MYwq6Oc5aNIzVCZLfaeyUr5s3Z3KZ8v1l++lfA6a3kO2d5/3\np12qT0Vt9VK2SnO/MoEjJNBBvE0JeKDVN66/JePqjyQTykeOHMGuXbuG3Z1czDm/Xib52A3DaBC9\nOIEPmqZ/7DS9f2XoJoeIz/ZeblCglzuols22UdQbqSc5EArDVo8f872YdJWoo2QENqDIYb/8MXW6\nL+sxU+zdPKvXtqoqV0y5Qfc4vBcMoxM2cDHGkkmYaRtn6nTgHVQbvVDHx1a39BI+eVDHMQjH72if\n7OCjKQTBA10NPvpuy9FrUsoy9Sa3tUvsT2VSUdqCjwF4OFlHmesXa26W898F9Tr7t1N9SQ+Cu9MW\nNjH0+Tgyhfo/pif5432Sj91oIPZCNYyIXp+Fpj1DebP4ebJu6+1FI5C3T3ltw8GSoYU1jUr+gKlY\nY7Q/sZ+qJVru1HfpY3kn/rzBzODuu9THOh/PvZMWJKbztTeMScEGLoZhGIZhGIbRA+bjUi+TfOyG\nkYuZmxlNZ5Cz38PKx9FLropethf3o911vXW/M/pxzPZ9LW9+lH/s0hfd90erY1DnKOoLaSfE1G65\nTbJWh32LgzB0HzyhN9PUJpqOGsPlPwF4FMCbw+7IELGBizGW2EBjtBn09Wvq/TEq/eonYtYg0UzA\nyvUla+7VTXvl2KsMLvJzxXSf76UoUIBmFtbZRKwoN075wc/ejkEL+JwEgavn3lamHDa65fvpHD3r\nlvdT+QfbBX1xLOcdDzLb6iB5Lsr1L7++Zr5PjN75Kff3NICfHXJfhoUNXIyRwrQgzaapTu952D01\nfAbhBN5/Hb2FTc6rJ9/fpVkz7N2Gf25qG8Ok7PXsPahEEj/AaZOsVaq+ovo1/6ZxvW7dsgr1f0yv\nqrm9JmEDF8MwjBFl2JqNJrRbTzZ2P/jo/kNQstC3u9wvSfajVNPWKLIddIyLsm/3IZzLB1Xo494Q\n862NJPvFMFoedZEHrvCbLvvJkwCAc49v8sI7XR1XpLRXnweAVvx/rN3hMgMMb1zFM1NnqGfDaCo2\ncDEMwzAMwzCMHjDn/HqZ5GM3DMMYGwZp8laFT0tv5jBt2qfVt0lNHTmBBkWRCVtw06Dabbu1/HDJ\nef5FRdqm4Dd67V15gjkknfO1MjU9Q93W3QQNSxP6YBiADVyMEcOypjebUTxno9jncUM3AWv3sW//\n5mO92vN3zhrfite9mVJxpvtwKd0XCSRAjvN5g5bFYl+FqC4eEOVHBusdH6Ag7vM9tHm3W15OsjOR\nidjP/8znAQDHsTXe9Byuj1Z+0hc/96wzG/sa1XFI60s2J0rVlDXtyjPD6yVy4CBzu9j70hg2Ez1w\n2bdvH+bn57Fnzx7s2bNn2N0xDMMYKzp9dFUxs11NHW1Vrn34lXUklzp9UshqnP176Uv5+toV1JG9\n1tqAKi63o9kfwHkO7nWEAi+qe9yDiiwsLGBhYQFnz54ddlcKMVOxepnkY8eBAwewc+fOYXfDMAyj\nb6r+eBnEx1Be5vUsWUfzXpyT6/2oKzs40TQaTpbJdL8/cQxqNKmnfNnMtsLj1/qcDd0cBNk6gzkn\nWFa0Ojxo2dFC+FSq71e55Xoq99FoMX3PG7Hoxg1PAwAuc5krPoSvxNu24QUAwNfnbotlz9zgNC7H\nqN773PLBfHM3Nd9LBfRzDxZd+0ExrHYFmVA+cuQIdu3aVXv7RnOZ6IGLYRiGYRiGYfSKhUOuFxu4\nGAY6m3MM0lbYGG8mOQ9CNzO05U2wymWsz9uWvQbF2d2HTSYLfGYbkO+TomSQL912J1M/125e9vmU\nKVjwK101XSvxcXZ5fnLrcvTzjKfNDrstN4h3UBU5YgyjH2zgYhiGYQyMXj/cCs2jSjgvFw9Acky2\ncvrTuZ/tLvt5kPbXyuWZnlXlM9NtnhlqNzapUs7f4gP+2ONBC5VzZmH4ydDLLl0BAFy94aVYdBu+\nDgCYRrRtxi0BoIUXAQAvYFsse+Z956OVb8z4er/jlp+ma/gpOQY63xkzPaGeCYbe7qWqAyjkUWdb\nhqFjAxdjJJmUmetRoSmOor1E4KmLJs3iN5mm3Etl6fcjsgnHG/VhryLrs17xgbkvt9jEU3QPDCLA\nQ7ruXvzHNG3gKDyzVTO1ClgdFJertM0QwMV622wKNnAxDEzmy9YYLJ00BpNwr+WHaq0263h+ffnZ\n0XUtw95SmeR1OofY7S1sc1ntj/voZIf4xew9Fw8k2CQq1jIcVD5elQ/lHS1qo53tZ5651adp37ud\nZuSM14zcfe0fAgDWOkd8ALjgrPl34DkAwJtYG2+Tcte5bQDw5tZo++Gf+DHf1jVu+ST1ZVk/xjLm\nT93ec72RF0iAwkon7qHie643p3stfLdpX4zhYAMXwzAMwzAMw+iBVauAqUtqbvMHMI2LYRiGMbpU\nnRuln3pKtxGHn82f+a1KY1Vl/pOi2epe/HK6N9NJwdoQoycGbf5UlcmomjdHCTIQLlXSnGE0Bhu4\nGCPJJJjbjBJNuR5N6UeapvarqVR1vpLZ6nXn+Ih8k7Lidrr3D6hi3wyLBXUsK+Zj/djmS36Wj9C5\nusctz1G5M255txddtzUy72ptbceyjTgFIGkqtgUnAACbU8uo2ssBJB32xYk/zhPD3M//+Gvuza7a\n6JdeI211vt8KIsX1QZ4pWXKCoRUttyt9XDSTsalLgNU1xyee5I/3ST52o+Fos6yT5iuQh52L4dOE\nDNr91F3nfVNncIIiZ+YyfRlEoAd9lrzdc32l250rLtNz3UEbuLM1uAZqoOj8lHVg73RvlLnGVWoD\nh8m4HIfRXGzgYhiGMQZU8aFQz8dGMpxuNEOd3+4g+1VFuOa87fnhmtskyQkKoDi8azP7QaAM1DjX\nSp95SsKwlfzIl3DI/5RkN7jl+vNe9s3IAX/6ijdi0YmVzQCA905/K5Ztd+nuV5HxvmhYRAuzBa/F\n205hY6aPbbQAAO++8S9j2TOHbolW7qGCX2pl9vV0cn6vgnLBH/Lur+R19toXf8+1aXur+y52Ig7G\nAD9YPUb1F5h8GkYV2MDFMAzDMAzDMHpgaioKiVxrmzWHX24SNnAxRhYzlTJGhabfq2XNMotkTN3m\nbZOWJycxq94hg33p/XNkie2/krt5rKjDhE9vN3mv1xMwo03/VeM/YxiDwgYuRmMp7Tg4oTTxA3jS\nGNQ1aKJpVFXtZp/dwZ1DzRSrm/2F/t43WSfwTv+n2+2XziZJmu/P3uw6Rym7wy3Z3GpjtH16tzcB\n27ghcrCXjPcAMPcz2dBWF11+lqvxUiwTEzGWbcRJAMA1aAMAZrGcqUtyvQDAzTgKAPgW3psph1tp\n/UtuKeZujuicJWUZSkbD4zqzsl7y+pSj1wAB2XrS+X+o3sfa0TLh37Qf4aOVND1STK0CVtf8NT3J\nH++TfOzGiFB2xqnsrHaTs6sbxrAZxqTAINrs9PFZ9vkv69Dey8y83yc/wWSnust+mNoET/fkXff4\nevSg4aqT6sKHt6OVLo530OGkDcMGLsZIYi9CY5Ro+v3aSRuS7ncVWtBBO8NHfWmTvNVTe0nKhnzt\nTqvTD6pz/hzJ1NDHbaUmJSywmIQ9QcX2Rc7205d6p3vRrjCiadmBxVi2Hq8DAFYwE8vE2X6aQhlf\nje+5bT6W8hYKfwwA68+/Hq+fmVkPALhInzIrmAYAvHZ8i9/pZrf8OFX0R255B31kiyZltkX5T5Rz\n54JKqMEQ+kENwqDd90qfK2NvVusU30t0vJ9uRctjtOvDtI9hDAgbuBiGYRiGYRhGL1wCoGbnfPyg\n5vYaxEQPXPbt24f5+Xns2bMHe/bsGXZ3Rp6qHZAn1cyh6Y7chseuVX9U+Ywn6xp8Ury8XDGd+lKU\nX6ZsuW5zZZRu9yNu5T2lqh1ryl2D3u+zMibQZfPHdNNOp7YS+www7w9Q7r25sLCAhYUFnD17drCd\nMUaOiR64HDhwADt37hx2N4wSlPmBLvsjbh+YhqHT37PR32Ch2iSzB0tmIu8cQSkkf/Ig4HLpevPa\n8tuTH5AiS56zrDO9tNtLn2UfLp9T3510DL8YAgDmP+3NtOamI6f498LnXZlGZDb2QfxFLBMH+43w\nZmRbcRwAcAKbM33mrPfrcQaAd8QHgOmL0fZ1L64gzfWbX4hW1nmZOOd/aOtXYtmffvOnohV2zr9b\nVpJ5hSK0c6zLKv09KZ0HRcuF5OnefNPvHw9aODDDMXeM99FO693ySZLtaCF8qkM+oS6RCeUjR45g\n165dfdc3UFah/q9p07gYhmEYRj56OOT2UNsvKpv9iOs0g96mujsnCMz7GOxmprrfGftkXe14vS4f\nG6M8/YY0LgxTrWwvcx8MQmOsPQPdaggNIw8buBiVUfVLaVJfcpN63KOIXaskVXw0935Oy2kltIhH\nZQZfWk6NjszuT2g/ZH/B15PuZ/rYFcf5bmezNedtnjk/5bZ/IoxF110bOdafd47uAHCL02RwmONt\nzjObwxeLo7w43wPAKlwAkHS0F82MLAFgDtFJ2/SSd87HW255IfU/gKk10XLjupOxTMIn34inY9ni\nz+wAALyGd4EKRjzR8jLODB+TzUxfBXpd2j2cDFOdHVR3vh966q9ofRapXokqdjmVu8wt7ydZHPwg\nPxeMvTeNfrCBi2EYhmEYhmH0whTMVKxGbOBijCW9OCQOA3PuHh3qvFa9mJb0kseoicfRad+q+jAI\n4jYU7UYv5m3qthwTnF4CABi9U8UzVD4xaHq/ds/122+MMQ7YwMUwDMMohZ7HpTX0PmT7US4vjUcz\n2cp+ROq5Ymjf5Qe6CiRS3vSspQgPZrezc7fIttMuYspzt8/FMr8pyotyy/TRWCZO8i1ykhcTrJvx\nl7FsK14B4E3BAOCapb+NZF4UM+WbxVvrLolkF/3U8YwEkOJAUq+lZPO0zcmmrvTmZqewCQBwHFtj\n2fkVZ/LWyvYJnIpmMT8haK+U3987+wdzbp9lzSyM7s37W9HywaoH6NQXiTb3KaUYO+d/0S3/UVmz\nzTFhGM75F4uLjCs2cDEMYyQYhnaq3/Cjw5rh7LYPdfW5CifdvBCxTZhRlgGNmiDSnOiNAvK0d3UT\n3693tobZDcNIYAMXYyzpJ+59nTThQ8soT13Xq5d2yt7zdd5zukN6ub4U7dtt+93v2yoooTlPa3Tn\nPK2HTWZNittnO+0rTuX3kuxLbsnZ4l0GedGyAMAd008AAK7H87FMst5vgnd63+xUH+JADwAbL0bq\ninWvUajit93yNS/CpW5JPvdrLnOaFk7cJ1oVnk0+naqXcY76a9/lK75+7jkAyYAB26ejsMmH374i\nWwdrDJRgCBpVPEOF97eWrT6GtBgPusARD1GflksO5nMHR9TuY+1o+VDLy3a75cO0izjvs4ZwOaeJ\ncWEYCSgvqbm9BjHBh24YhmEYhmEYxqhgGhejdppi2tFvbH2j2eg5R8rJ+mmj/L5t2reVqY8Zxr2Z\nd2xVPztph+N+zag6OTCn6y3K1VKFSVt+3hj2U9HbCj7WcxeMPtBMtiTEdfemmO3E/3l5gnqhzD3S\nlN9dw+gXG7gYY429oMeHYVzLfky2Romm97mJ/Ss28xKyeUDyI0PRQOfeVnazmAFdRe1/3JVjsyeX\nq+Wyf+JjhfC4AAAgAElEQVTNva6ei8yn2Nzrvfg2AGC7y8kCeFMxMQUDgHXPOHOwNdSGONtTbpXY\nRIyd82WdvzjeUPbVECswKUcO/tgQLWZ8ehhsvibqwPV4LpYddTZy0ze8EctWPrcuWrmKG2tFi8Xh\nmRjnThLscNsWlXtkuU177S03+E84/u9PtB875APAIbd8kWQS4OGaGS8TS7xUX8aeYTjn122a1iBs\n4GKMNTbLZIwjXYXYvcmVe6p43zLZ4qsMadxJKzEKoVx7CTtsoYpHG+2+rPo3Zti/WfK+SA7ojEkl\nCIJ5AF+BH579VhiGnxtmn2zgYtROUz5AmtIPYzDooXvLyfppo/y+rUrr0+qIP0Iqptd+5oUj7jWg\nRj8hmjtpQPqP+JUcmGRNg+R4FQftHXQ8D0u/lCzmL1N1u93yfV40/yOvAgBunH4mlkk2+9vw9Vgm\nGebZmX3rUhTmeOZvqI1Ft2RNioQmZi2IaEZoIj52uucvDlnfQDJ26BekPXHwZ42POPG/waJoKvok\nNmaqWjm0zv8j2qmPJ8uEvwQEAQlciGvNPLLsvdrf/UTX/piyWe6RwshfymA5zzlfHPIBxFrDU778\n9KXRRV/ZThc6EeggtS8Avt/HimEkoKyvvTcA3B6G4dtBEMwC+E4QBP8xDMPXi3YcFDZwMQzDMAzD\nMAwjQRiGIXxMv1m3DDoUrwUbuBjGmDNs0wOjewYROKIJocHzc5yU758++91OybJtdK4nOxtd5TXQ\nfFqCjyA1q200gYRvh8hUE7G2vn/BfdP9fd6bWWFwE1K+Ovn1DEo7a4w+zlzszxGls/2VMAxPF+wy\nUGzgYhiGMWKU/YjW/Fry9q96YKtnmi9AieI0OsjH4UFFRtypnWetXCtavkcpvs/bZ4nZzvoNZ2LZ\nRpcSnrPa/yx+HwBwK9n0XInjAIArXqF09WLu5a3MfD6V4yQTKyH+kpB92aTrQmoJeNOvtwtkSMl4\nm1iDkXP+CqYBAHOUQORNrI1WOI2LmIh9lmTi13HnfoSPRqv5fkklneA7UC7aId1Ly9k8M3FEsS/5\nYtiutZY12YqjpPGgRc7BIskkPxCZgm3cEN1fb37A5/A5d9Umt9byBX9tAvy5GprHJQiC2wH8CoBd\nAK4EcHcYho+kytwH4H5ET8dfAfgXYRj+Fy4ThuFZADcHQfD3APxhEAS/H4bh96s4jF6wgYtRC1XN\nXo6y9mCU+67RxHDSTexTVXRjY1/GX2SQz2TVTui9aIuqCGlsTC5N10AEv9HHvunnc0er3+6Ua3fO\nr4/epMRIsgbAUQD/L4A/SG8MguDnAPwbAP8jgG8D2AfgiSAIrgvD8GS6fBiG3w+C4K8A3K7VVxc2\ncDHGGvtosXMwigzimjXhPigborWnviaydZd1mu7cTm/nS2a1acAWfxRSfbFjPc2CH3TbD1F1t7ol\nawXucMsz3in66hsjr+2XTl8dy27ecBRAMiywOOCLNgYArnjWaVo41K1sZu3K2dQS8NqVeaUcO+cL\n/MUxr5QTJRJrZkSr8payTbQv81w86vx6eO3TZqeSufI2f5Cv/Jgz07+/5Xd+Qunzjv2x5rIMRfdN\n1/eV5kD/CVqXe+RVkj3W5UB/se3Xj7Wi5b2tbDkKZCAhtV95lco97JZ8Hvm5HFcaGg45DMPHATwO\nAEGQCDkh7APw22EY/ntX5uMAfgrAxwD8KyfbDGApDMNzzmTsgwA+U8ER9IwNXAzDMAzDMAyjgSyc\nAhZSXiVnL+plyxIEwWpEJmSx7i4MwzAIgq8AeD8V/SEA/86NewIA/3cYht/pr/X+sIGLYQyAYZuF\njbPJ1ChS9n6o6r6p0rSqm3upqgAAgwgkEPvYJDQz7Xg1rQ2yZ8gQsvdj1tekfF3t3H1L+4IZzWHA\n4ZD3bIn+mCNvAbsW9fIl2YRIb3MiJT8B4Hr5x/m73NJXSxVjAxejFqr60R/lj4dR7rtGE4+niX2q\nirI5aHpxxO9noNDJn0b3wdmfKZOmyG8nKtPObk/YzNdwH4gJD5ulaWY9Yobz6ZaXST6Oj1N5yRDP\njtWSl+Vmkl0RAgAuu8Kbe71wPNrp57f+TixbQuRQsI2Sf4j51NY3KGGKVMM5W8Tc63sk00y1zqe2\nMadoXTML0/K4SN08m5x21Ne+WqhPc0uRU/6mOW+iPwVleppNxAQymYqd32uIxqfnE3KDI85CL2aH\n7Ih/v1t+lGukABdxkAFXTweTykwf2ASMgxo4Loit0qtkgXSvWz5EBXe7ZcZ8bXzf1cZgsYGL0QgG\nraGw2dPJYBSvc9ls9YNwpq+iXBX025a2f9XXPgjak2GvbwCo9v5P1lVvlC12iM8tZ5qeSeMkoimC\nlC4HW5D0mGocNnAxjAEw7A/mYbdv9E43Gbk77d89+R9TZeqs8p4rOgdsYlP+XDlH+GWeXc7J6s3a\nE571FkQzcmx/VnYVF3R95aznMjt+c5jb4x+6NnKsf+X01li28naktvjxua/Esq1zkRf9WrwZy8QR\nn53UZ5yKZIq1IaJ8YYMR0b5QRvpY88HO+RzyWLhUkUkb7MQ/ldoGeEd8zfFYZNym1EEan2nXz/Nz\nXr0zjShk70Wu+Cfc8m6lrUToYE819/jBnHr0dmNudfuxduWcUu6QIpNBtxq4gp9/14fHSHav2/cy\nL/rb70bWRNtu8+4OL3zGxe3m4AGiHeoyyMFI0dBwyHmEYfhOEASHAXwIwCNA7MD/IQC/1W/3BslY\nDVyCIGgB+DyiEeMFAO8Lw3A5bx/DMAzDMAzDGCeCIFiDaDpF7PmuDYLgRwGcDsPwJQC/CeALbgAj\n4ZDnAHxhCN0tzVgNXBCd7F8Nw/DrQRCsh7fANYbEsJzUh+0cb0wGZfwx8vbpxsdDr6udardV2GZx\nncVle80OXja3SlU5NHo6l2YOZpSkbvPNUWdsf5cbGg4ZUbDsPwMQur9/4+QHAXwsDMPfC4JgE4Bf\nRzThfxTAHcNMLlmGsRm4BEFwI4CVMAy/DgBhGJ4p2MWYIMbqJWl0ZBSvcycn+fSxVHdsWnb3g32b\nqHWiTDLMxDmQQUtZ0xIy6SpKatf5HCqmcuwkL9F72GRM8l18kcp9wy13eNH8PZG5+Nm/9h7ON+/8\nJgBgFTmNn3R2UrfgaCz7Ft4LwGcpB4AfR2QixiZgW13CFa6vhXZiCQDvOfZC8ngAb6rFOVtecks2\nC2PzMkFMh/gjSkzF2BFfMykTh/qir5D0di0M7Ea/urTmElfMd+o4IlO7WdANIlb8u6mex/wzUbXp\nY9dogR6kz+ws/zll393U9qPpjSWDcnBSyofb0fKjXibBIS7wxZdgEn9N9UjeoQcnY3DWJMIw/HMU\nGJWFYfgZDDkvS7eMzcAFwA8DeCsIgkcAbAXwH8Mw/JdD7pNhjC2DzLxeJb30s66ZwV4HCp0y04sj\nrnzADyI8cbfnI8/pt3yY6Gwd3YahLeqLYTBFYYs771ccXa9e64O2W1OSozaQsdXKGJXRiIFLEAS3\nA/gVRMlwrgRwdxiGj6TK3Ico8N8VAP4KwL9w8aWFKQAfAPCjiKIlPB4EwbfDMPzTGg7B6EDZF0/V\nLyh74Rl1UEab0O0+3d27pDXRZmjVdttOslf5INM+arIOw8V91OrR2svSrQNvkZaF2+8o49llcax/\nmYpJ6FzSpMQO0OSwPP2/Rt7sN254OpYdPR6lQHj/zj+LZdudp/6bWBvLRBvwEq6OZbfiycQ2wGeG\nnyPZZqc22QF/8rYj0q5c/iK5eT7jlhz6WBQ87CTvtCvvkOxN5wD/DoUennXO++s4pLFoRDhssmhf\nNMd+Liewg//5VDnW3oizPznnL89Eo/dpshSX8/KNI//AF+TrK9y5H+Gj5Qe4dYT5T5hNHnLL95Ds\nn7tlm2S/4JZaUAkmDundzsoW6f30kJNRrKm5uej+48AR063ohlh5e50v+KBb7hjj3+TmmoqNJX3G\nJaiMNYhen7+EyA4vQRAEP4fINm8/okQ4fwXgCWebJ/wdgCfDMDwehuEKgEeRjH5vGIZhGIZhGMaI\n0giNSxiGjwN4HIjDsaXZB+C3wzD8967MxwH8FICPAfhXrsx/AbA5CIJ5AG8C+CCAzw6460bNDEqN\nbOrp8WPYDq/9moFpmpnqc5P0VndyRrq8CUpd12TY194YXTRti8i0pJS9m8gm2wnDlv5cjammIn1O\nR5op1P813Yiv9+HQ+EMPgmA1IhOy3xBZGIZhEARfAfB+kl0MguBXAfyFE/3nMMy6pTH79u3D/Px8\nQrZnzx7s2bOnqu4bxthSh5lEVXTbxiDKl3G2L/vBXbxv5/7kZQTXPiLUqaRCCvJRdEk/HzdZEznq\n253uPLHpjTihsymR/NJwWrZPRMYBkmsFAG7FYQA+hwoAbNsamWyxM/0qZ/fEpmIX3c/x9XiOykV2\nV1vJc15yknC5GxGZpl1J5S4/5kzEnoFH1tl5+kW3/J4XvXE6Wp6grPWSIYY/Gta57avJBGxWVtg5\nn0y5Yt5WtsnPMZuDiYnYTGrJ2+hnXM7ZFHnxy7kVUyYAWPmUM2fqYE7lnxN9eye0Z7Ovd9witZ8X\n8Y7vTTom/+woJqpxTiNfrzdN88Ex4iSWPnVQfJ5bG3xbJ1Y2A6BzCwD3uOXXqH+PtaGxsLCAn/7p\nw/H/d911F86ePauWNSaXxg9cAGxCZM13IiU/AeB6FoRh+ASAJ8pWfODAAezcubPvDhpGlYyK9mdY\nDqdVt5t3vvt17C+SVzFbqw82utc4RHUmBxzDuP/yfH+q8QsyjMHRPOf8/HdBtJ20peTvVXeIcG3i\n+MiRI9i1a1ct7RujwSgMXAwjZlAvfPvwGT+acE27dd7vZ7a2U1vl9u8u0lBysKTV7/rykdR+uTrw\nKikXZEDNMP4Bt/ynXnTdbdHU80aKCbzFzaVxtvrzmAYAtGkG+zZ8HQBwDNtimezzPM29/QNEzvus\nhRE2k+e8aHNYqyP9uuIlmp0Wp/vvIit7kWROSXOaHPFfdpoM9tcX+KNBFB6zpDWZFcd6zqLGWpJ0\nRTOKTHPsv5haAqqG5gzWAwCeokgKX8GHAAArryqagIe5U3yP7O8oq+LdUqxFVMKW73btcpCIBbd8\nSKtDuec5iMey8l5abGfN1u5zy6NU7rZoIVoWgEJ+/zKVO+aWHML53hbCz2v9HVEuQf3O8k3xUB8C\no3DoJxG9qrak5FuQVI4ahmEYhmEYhjGmNF7jEobhO0EQHAbwIQCPALED/4cA/NYw+2bUw6BU703O\n72EMl9imu462VCfdons+q1Eoq9Xp5ti6yzyvlL1TM73TtTtFM9B5fclz9LXcLUYvdHvfdPesRHU3\n1TE97zmtrI1UzqmRxsIh10ojBi5BEKxBlKdY3ECvDYLgRwGcDsPwJQC/CeALbgDzbURRxuYAfKGf\ndsU53xzyjSYxKgOiYfWz6ecnz9yruo/ogxWfh6i+YE4zI+njA+axB3rKdZNtt3MumbzklIlt9yrn\n66Nuec6LJNP9pmlvFibZ5zXHeTbtknLsiC/bNWfx2+NYMp4dlNZe2thCLp7iqH/zae91H4hNFzvd\nazlbjqeWAE44p/y/o2LS2hvIslpZp0wxcZ4XLhcfumZnxo74UMpdTG1j07K3kUHM9c7RdbnF2Tj9\n7ZkbfMEn3TLhv6HkNSmZfygPflZz3wH3JtsJPw8EN9F9K2aMi8jCMVT35kT6U4MRKCZlnNtIPIe/\n4EUX3Zfz2Ze9MczmndHN9NrT7/IF5Tx/SWk2h4WFBSwsLJhzvpGhEQMXALcC+DNEOVxCRDlbgOhp\n+lgYhr/ncrb8OiITsaMA7gjD8Pv9NGrO+UaTGaZDp6GTDlWsl2nH602YUQ2CduXOtd3cm6U1QT3P\ncO8lmaujJmdiYzLoN7BGJ21p5h6+t5Xcbw7RlO4Y0+l9KRPKI+GcbxqXWmnEwCUMwz9Hgb9NGIaf\nAfCZenpkNJ1qnCO7r8MGD5OBmC/0Fgq4y7ZKDm66ufeKNDzR8SmaITLbCAL3MVXhICBj8iY5Kjjk\nawzPAqdnjkuGW+a+3++WHObYZb3fdtt3fJfcdPYqmuoXjYfM5gPAMiJbl20uQz2Xe46c7jfiJABd\nC8NtiLP9DHm1i9M9O+JvX4raC1iTItqVZ0kmE9WkXZFqTpNMNC0cttNFQ1Y1LrO0Lq7urHG5oGlc\n8pzzuRFJwr5KKSdL1rJsdEsKhzzjwkVzQIPnkgFII+5Q+hTfh/2F8859VuWe1BzjNa0EZ7C/1dW7\nm7a7exif453885KXeyZ+xrmcmJLeStU97PY96Y/r/Er0LHzoWh9xQ4JSvHYp5xEPsn3uEA7ZMMrQ\niIGLMXqMsq+H/gLv7nhGXRtS9nirvs7Nr69N9bUqrE833ejG1r03LUdnM69EfRJpqMTsbj/mbnX6\nDhnGIGm6n4rg87KQTHkO4/fB7Gj9lhmThw1cjMYzaoOCqpjU4x4e2Y/8pG162ZDGLVe+rWzN0yLo\n7VZCZna3i/qXNTMXpe9FYVa1D6LFB5wWhmTk0J8Onxx/cO2muiR55HeooIS65Vljx7YP+4LvxbcA\nJLUhs1jKyES7wpoPmcXncMhi9z8Hr7qac/qIFVI7SMJIRvYRPxmu+z2veK1OrEHhkMYvprbxOiWW\nXHZqlVMUbvhEagl4DQprUoTVSrl3SBaHQ9bQfFwYUTZxHemwyZwzWrQv5Aax9Peia8XX4GncmK33\nGrc8BoXk/Z0enOh+VXlJXzUfF+87w2HD5Z6P73UOcCH3NWtm7kktAeCQ629iIkLToOZolriNT7s+\n/IkXnf2RywEA01u9hlC0XC+8zRldHY/p5nJNH/iVYhXqN90yU7HJxJzzDcMwDMMwmoU55xudmOiB\niznnG0az0cMCtyuvN69MHaaDaZO3svX1ei66j/A1OPJCr8ZmLuJ7YE73xhAoEx441wS5g/lVvP1O\nRSMzIfd6J3Nfc84v0eaEMtEDF6N3xs2MqdvjGfXj7zYbe93tlqf/UKVFjqy9o5th9BweeEfRucv5\nsOJ9FxX/FzHtWswPQcxkznvCLGU/wqdSx6iGYVXaesz1gcOxpts4RDLJcH95tvi2G71Z2LRz2r4F\nfxnLxBGfzb1OuFzHF+nnUcy3NGf6FXLYfw7XAQC2kGP4knNnFyd9rodlYlLGIZcvf9EZY7FZmJh+\nsSO+EuY47gJNWL/hMtyfpmJi7nVBkRWZimksO/Ot2a0kFDMvbkRO7zpFxs78Yt7FJmKCtEHlxVxP\nHMUBf/2ev4Kc9F90Oy0XTY5ozwHLunynyX3NTveas7o8L2L2BfjAEl+gco+7JZt2yXOiBb3g51QL\nq6yFQf81t6TB1PynXwfggyEAwAvYFq08Cc9VbsnhyKWvmkmpYRRgAxejEXTrFD0o5/hBJbs0khSd\n0yZpBDSKggLkaUKKjk11pg3amQ/5YSdWjG3w5eMjNbAyR3xjFKki+WLT319NpRsttzG52MDFmDjs\npThapK9X9c6c5ZI55mtKij50ZLvmnE+y+ONfqW+xrTr+l9ISLSohUNkUZbtrlx2Vten2O90+h7Q2\nfJ983XuzskS9Sl9i7Q/1+TNuuyTZ+yJVcUW0uO5nnopF4lh/kewpfhxfAQBcSWoJ0aqwI/7rWA8A\n2ASfgPKUi7t7geqTmWaWbXehkU/FcXq9BmWWnMVlX3bEl1DKlz9LJ0i0Kxz6WNZfI5kcErsDuPU3\nKNywaFrepGKag72mhdE+Ft5Ryr3jlFKz6cJAMtlkOswx4M1ftHJaokppX9HG8HV+QmIff4FUM6Kh\nU4NKJLUsfU9gLVMiVmViIm5PMylLaCpb0eJxEn3NLTm8sygaj7W8LE8Lo8HPpDx3pNU5ezI6gc9t\n9Vqs1757dbRCCV1j7QtrYeI29lPo+REe7JmpWK3k5k4xDMMwDMMwDMNoAhOtcbGoYuPFKOeWMeqh\n06zeqMz25eZfKNq3RG6XphF8zK0oYY0Noy46mWV2897QNS1Gp3M7UlHFLBxyrUz0wMWiijWHpsRy\n1wY8NgiqnqJzWsc579lJXq2rFa/nJzgtGDRIXpObWtltbMalOfiqaCZqB10b3G47WoopGAA8lq4D\n3jlYc7RnHxw1AEDOPleR7Arl2n/ZLR93OSPe9g7xH7g2MgF7zTnVA948ayOZe0mOibVkx3IcVwKg\nPB/wTveS3Z5lx+E9zmU75wvZ7My9NBmbnolz/nu+T/lZvht3yiNmYexNn+eI71Nq4B33vfcmZZrX\nrP/KbCviHU3I9mOS3Z3zqGjO9mIOtpFkYt0lXytvZXc7P+ONRyTQAgdX2OZM+I7ufp/fSTLNJ5zV\n80w6iwOBdIz+pz1rWsCMxDNyMFtOcrW8TsU+4ZafItljyntBHPET7WrvI9euZt7GuWJejS7MM/Ts\n4FLnqH83lTvjLiCbiqmBOpJ9GamoYkatTPTAxRgMVTmz6x+A7Z77ZYw/gwikUOhMn+NQ2sugKAge\nKBFBrD/qaMMwxpVR0dD2S/x7q0X4M4whYQMXY0TJz3JuGBrdatR6+0DRZm079aeVzBovaNm8OXSo\nzJ5yVm1tllXgUKQPa+VcXx/j50pxnNc0KW4mOjGpoA2K4mPiGV+3z8epDedsj1dpXzcrvm1rVMlL\np6/OVH8HnojXRdOynqamfQZ7r63Ziley/XSwY/95N+3P4ZA5lLHfJ/pJvR1/Ectkn62kIrn8r51+\ng61gJOQxa1KecUvWMsh21sLIdtK4LLt18s2PNSOahoTDHF9ILRnto4Ed8WdFQ8IhjVcpMoE1L6KZ\n4YZlnw3RIrzGb1paE2laLk75Xr2E7L1xxgVckAUAr2l5uJ0om30m84N3lPrdSTnEd3xeEuXcM8Zm\nkqxpEf5QkeVNSiTa8O8oPzmYah/wz/39VK/Tnl223od6mJuLNI2xkz4A3BNGy2N0Uq9qRcuXkSB8\nCqOJOefXijnnG4ZhGIZhGIbReEzjYowFncx1uvE36GS/bHlciuk2MEI/57Tbfcvm5unX/KMX5/dx\nMTkxE05jXMgLgFFkDpr5/emQy6iKXDFV04R3kbxHmuLzWhrTuNSKDVyMyqnqw14362kBaMZL1pgM\nujclE9OS/VSuTfW1kvvuUEynlilnS4ePnzDcn9zmciIk++RMQR7mPd0H0zFFppm3Lec48Cb2VeDg\nAWKu9k9pu2QFZ8dd5wD8X//SV2PRtLOBkvwnt2/wpliS/+Q82SFtUsy4xGH+GHlji4xNwFYpBlJi\nfrSdTpq0xzJxxOcAAGsvRqY06/7GZxiPzb1e9KLY9Ot5komd1wmSvZVaAnhHcVgXp3ztR57NwvI+\nAtgELK/cak04paxzLpZ1bsnmYzNKuc3R4vwWZBATsTdX+UAKJ51n/wzZzcWmYhSoIOHMLohZpJrb\nxdNfYA/J2dLyInlOuN3YlI3bcM/aE7Tv/W75SSr2j9puG5V7CNl2ob0zlOdZ+rVIsh+JFueObopF\n5zh/iyDmf/yML2oTim1lZ8PIMtEDFwuHXB/pl9IwZlSaONjp1KdJ1+oM8rxUp1npppz/GCgbFrUo\n83wQPJBJWGfZ6g1jcBRpVTPvBi2hZMMY9oBhbMIhm8alNiZ64GLhkMeHTh+0nWbGdNOg/DqMznR7\njuo8p9xWN4OW7vpY0uxDi86jOe7yACQOQbof4eejtfg4eDZYPpISs8VSdzIcstTn93X9SmhXFO2L\n1J0KZ5rpsyghcp30ETvuXnaFDxV861w0NcvO7BJ6+G78EQCgLRnEiXfj6Xh9ymlQOFv9ipvOv5HK\nSRhkbktCHrPmpeVUI6yZudqltV+byEMfseUNfzxT4mCvZbpnjYvscrqkzHcldsRfTR8zWlZ7VTPi\nYO1KnvP+rCLj8qtFW8KalPnUEvChkfkrxGlXOBzyq9dEO8n1m1Y0KRy6Wta/hffGsthhP6uIS4Xx\nbruV5L3fsympPCes5dDiTstzxaGZj6W2AcBut2TthTjvf45k0t5DJJO+JEKet5XOKM/99v3Z+va5\n6/Cqv9CX3Ryd4HOPey0MZJVDKR/r/B4RLByy0QlzzjcMwzAMwzAMo/FMtMbFmFy02bM8B8xe6iwT\nKKCoLtP21EOn2dRC2+8u6yu1b44pWfCRnqsdKE3tl2FUQRPNjMeRkf3dW4X6TbfMVMwwBkvVPi39\nmCblRxqrl6qSFo4bfedN6GLfas73wey9pDn4HuP2/UAodsSXQQubUIhjPZt43Lkf4aMd+q6acWnm\nY7yPUo/kiDmU3YR7qS+Sb4XNXK5yy1/2oulbI0/zlS+ti2Wbr40y0rO5VQtR/9gkaBcOR910hko7\nyEtY8q2wudcJRJ7cU2RPdcqZEHF+FnHsZ1MjaUP6wfVcjZcy/Zwjc7TLX3J2QH8Dj3SLTcXERIyd\nmSWlDJv0yzrlZ4n7+XZ2/XS2WIKp1BLwPvLLiowRczA2N5Ozlih/aWrJsNO9mI2RWVi8D5mZybk/\n5/LvnIjtybyp2ArtsIzIZnEJ3nZxacmts5nifW75IN37cT4Vpe/QJqPyt8fleDLiDlfmO3obGe6g\ndUlVxPlcdrvll5R9d9P6Y27JuVN2tBA+lToOem+F7taO3zOcD+qAO+e/GMaic1/YlG1XzNo4GIL2\nDiqR98owABu4GGOAFrFp8G1aiGSNXkMP9xMOOa8OrWxZe/U6nVZj/5DtucWS+9gA1zAaRSbM8Qhk\nnLeAHhVgzvm1YgMXY+IY1CCjqN6y7dogaHhkQnOmogJFoUMLHNgFnlUU7QXPdsqsLjvuxjPCSr2H\nFA1OQdjWiNT9JB9THBQgnmlW6thN65LVnp2DZUb4AyT7SbckZ+gdG6IDXvol/6Uk2ecv0k+RaFpu\ndVoWwGtGLrhfa9bQsLZEWO+mpE9hU2abxnqciddX3Mz+Npqel/6xbNMbkTpkimfnReXBGhcJVfxd\nRcZamPOpbSwj7co7ivZltZw+8sQXDQo702sy2YUVH6fQGdauSD0Jp39RfrAjvihJWOOyIVWeyr21\nwfX2GdcAACAASURBVLvfSrAE0a6wxkyu/TJpV2JHfOLcGXePfJmEmmP64gNuYoOFnU1ESwf++CSt\nt9zymySTfr2HZIfckp3aP54qD/iL9VGSvZxaAl5LqmlmXCh1ID1hE+0TvxfZJNRpWuev8rG6z253\nL4g/onISPOATJPuU68t9JMN+hP9a6ZthpDDnfMMwDMMwDMMwGs9Ea1wsj8vo0qvTdHZfw/AU505p\n19KPKjHHecMoT5nnZRx/Q7R3W/w+FG3unfVZA1gelxJtTihBGIbFpcaMIAh2Ajh8+PBhy+MyotTl\nI2E0j6qvX64zfYL8AXLav6pwcJ2X0yWR96GdLRfnXVHyuCRM1Fy5hFnMwWR5hn1stGzeu93yCir3\nz92SnLFvvjGygzm25Cu8a+4RAEmnaXGyZ8f6jc725RQZL/F2ANhMNlaaCZEgTvqAd6LneqcRZbPn\n/CySv4XzvYhp2jVLfxvLZsRcjk27xGxMy9nCnvPyLcb7ijkY5WcR3iHbrQvOtusdKif5W05Tfdp3\nlHSBHfGXc2RLJNPyuLRkSSZgs9e6FU69sdUtryXZD7ulYlJ28srLYtExd1O+6VKwv0A3qVw/zusj\nzvtsMvanp38cALDyZTJ0E7Orwuel6NlOwR/3Yvq1QynHz5BYIH6WZLemloA30WSZnI77SSbmm0+Q\njExD42AgakJN5f2gDVzE9OtVZOGgE/JMXE6yr7nloeRu4RIyUB6XXWEYHlFaGxrxt+ReYOcVhcUr\nYeFpYOEZ4OzbwFcjU8DGnZdBM9EaF2NyGPUZsm5CKY9Du4PCzypWH8FmGEEiDMMwuqXJv4cj+ZtT\nYzjkPTuivyOvArs+X0+bTcMGLsZI0u8LbWReiEaGgV275Qeobi1M9sGcKGntUv1M7Lvo9mXztNlW\nFAAgJYvrzDjQKpoc1tYIiWzZOZojDhcrDvufJJlMhP9f2V0va3lPfNFg/Nzcf4hlorXYSB77lzun\neHa2l/UWpZWX2XPZ9hqFxJ11egHRvABe+zJDcYSPx9P+HnH230IqEukfhz6+4sWzUolH1p8hmag0\n2Lv9e275BslEM8Jp7ckBXxBH/NX0S33hglLOaV+KftBlO2tNZJ0VQhL6mB32BQ6FIPqLKW5YnO45\niIBUdA3JxCmflCAvXnklgKRWTq7rc7gOQDL0sWhXOEDDjNPCPI/rYxmH4I4RTcUiTWI8Js9tK1s+\ngfIMyTN2iGTiMM8aiJvd8gqydrkqigYwfY+/SVaedX0+SvuKduNFksk6O/FrDvj3uv49rGmC6Ryo\n4ZCd4BDtKsE4biDZJ92StT+ibeJ9RTvBfTaMktjAxTAMwzAMwzB6wXxcasUGLkajKOu7UkcelZFU\nWSuMy3GUoThnTLlADt2YUmRyN2hlbuogDx7I+JoEQVvXmqCTTbphGFWSeP7VUOGT8fyNYjASY/yx\ngYsxEYz6B/uw+j/q5y2LmHslPzzq80lRnGCXlQ+i0pmlSbbs9mWn/0PKLlpQADHZ4OzW4ihMpipi\nyrLxUW8LdT2eA5A075G8K2zuJWZhs+QGLg7zmqkYZ72fc/uccR6+Un8kW59pX5CcLIA3G+OcLWwO\nJrx36dtR+RMklGKaqRg74stpYbsrsf5hR3xnOsQ5WcQEbJaCHKyeyZYTszA2GZt15djBXjbzj7wW\nNE/MwjaQbDa1jWGjq7Wur6s1m7LNtC7O+1NZ2fktyLBExmxiJijXnoMrSCCHF5TMrSeWqOL3ueWC\n0s8d+xE+pchzcc8dO6tLzhR+nre77X+iVLGbksWsjy7w7GXeO31FzjQ77IvT/U+QjM07BXHeZ8f5\n+BTROyieINmfcYxXBy18msUc7eMkk/5x/hjpH98jD2WrBgB8fhx/c4yqsYGLMTaU1SxMkgaiE3We\ngzq0Y2Xb9rK9hbL+2277f0Ygg7ZhTCoWWKMZiGY6fIrf3cc7lm8MZipWKzZwMRpFkwYSTepLP4zL\ncfRDnPk5/jE8qMiYvR0/YBLZsmkKWwvlGaNlpKe2PAcVmYNNymLHYqUcz8BmJ6J9WNT7W14mfu3s\nLCsz/+/zoulLI8dn1niIg7toXgBgG14AAGzFK7FMtCsceniTc4SXsLbRejT7zKGM0+U51O1JxYVc\nHLg5jLI4cLN2Rxz7t7v+AsCMhCpmB+i/cUvWpIh2Rct0zzJZZwdtRWsShzcmJ33WvsQyp125QB8u\n4hy/bk22PLN8PisT3cYs9UVWWeMi4ZDXUp/WiVaF1TUi48uyJlsudLESjs1ti2WiaWENilxrccRf\nhLe7lPthlgI3y/Zzj29Chg7hgdMknnFlkic2/WTNgnA/PafipP5J2u6c2TmYxY1zUehtDusccxWt\nS/+/Q7L3IMuTiuxTiiyh7U3+TvD7L5gTc7m2LyDBCHzk6kTY5/C/d/tKoN5dtK9mCqu9qwxDwQYu\nhmEYhmEYhtELpnGplYkeuOzbtw/z8/PYs2cP9uzZM+zuGB2owtSok7P1sEym+k6W2Gc9RveojvE0\nc2gmiIYx+ojZmKZxjTWsY6gdyCTi1ZLbdlPfr7iVHj6tor4suj8lTrgx0Uz0wOXAgQPYuXPnsLth\n9ID2YdjNx6KWj2OSqPPDepgf8eXa9gORru3bYyf6Asf5vHwJhY74OeZg7Duj5UT4NVf3vVyulS3n\n8ipc9m+9+craOcmn4vsnpldsbiXb2dGdtwuciV6QfCuch0Mc8S+SE/1xXJkod55yebzmTMo2k/na\neeeUzw774sjN/bzSHc/lz5Jbu5h2fc+LYhMxzWH/LMlknU3FcphSfoGXFUf8WX+4iZwuad65SOXc\njCybm8XrPFvr9nlHyQ+j5YyZ5Uz3sq6ZhXE5t/2Nd/tgCadWRULOvyOmUnx95V76Ft4LIGmm+Gcr\nuwEA26e9qd9LS96MMOYbbskZ549FbanBMTT4411MP9k5/7F2tLyq5WVfcMtvUj3iMP9PvEjM4c6v\nTGfLSb2Af945SzubvwnyLuB8LrulPpJJ/x8r+C1cViZtBDaXk/cNm6E+Lm2RTPZh07NFWZF33w6E\n4e/jyJEj2LVrV37/jIliogcuRrMp0pLYrLZRNWmflV4Ht53CHxuGMRpYKGCjNKtQv+mWmYoZRrPJ\nd6Quv3+RbJBU0Z4N1volO2MoWpZAixWrwVqOxRzH3QQSDICdftvZYppJhmhkEpoZNyt5FZUX59v7\nqJjMfLIzr8w63+xF0zdEMXtvnvvLWLbJaSg4fPBt+DqApNO7aDc4+7w42HNIY9GusDZGHPUv0q+w\naFVYdtH9VImMwxxLX9jpf60LCsBtSTnWuGw87TzmWWsimznMsRwua2HeSi0B75w/pcgYcbAnKxjW\nlqTRNB+a5iUh0z5sRONyIStbzeUuKDKpmzUpEhuZQx/LdtISiRZmaZUPcyz3DV9LuYaiYQO8NuI1\n1wjfj8LhP/ixjAzP0rqE32UTr/h5yoZGTz6bSohyccDnsL7yXvgAyST88ilkOLedgge4fc6d8ZpH\nfDlVL/Mw9eVet52PjRzxJWhIfExF4dLjwB8szGqlg484wetUTN435KQfh0vWzOsS79J23JZFdjPy\nsIGLYRiGYRiGYfSCOefXig1cDKMHmuAkP8rO4HWev2Rbg8t4XcZxt66+GIbRG4PI6TRMSmuSy9Yn\nmhv2WakYMwc38rCBi9FYmmDeZYwWxffHwc5lltNmiPuhmZEwQeC2c14CMXkoisQj+7AJiuaoL+YX\nD9K2e13dnK+BTcSEa9zyH5Ks5WyXznhbnrs3/CGAZD4Tya3CplWSfZ4d9sV8a5psoq4+H+3z5sxa\nKhf93HDmczHfOkG2RmI6pOVnETMyzvHScglXlskRX3LGSJ4P7vOm71NCle+65TPUiDjicx4XMRvT\n8rNw0CPFpCsPzTl/tZKfhU3FVs8gi5iZ8SyskgNGzWAv9Wl95zrkeDlXzLwic/lZEuZjTnYK3jxK\n7oOTJDuGbZlyct/I/Xjou3fE2y67wtlg3UBtiSXZ50gmzuqcST7jDM6QLHZgb3uZmF7yO0NyKnHw\nC3n+LqeqxWGeAgWs3OrM5f6aLu6r2XLx8/4QtSH36ddQgDumDiZgMWL+mnp/RT5/bS8Qh/6XqZxc\nmkO0oxYoQKsvfh9ObtAcoxw2cDGMAspqB5qghZl0qowUp828ZusvPzNrzr6GYYwqVWuixup9aKZi\ntWIDF8MYUUZ5YDQ6fT9YLjCENku4ncOntqMlz2J2CKUchvu94ysAPOjqvpf2fdjJnlDO4/bQr7tM\n95et907qW+aicLI3bvXhicXheSN5EYsmYxPJpByHpJWQw1uWvDf7m3NROu3Ll85mZOwwL5oT1pZw\nCGMvm03sm9QCRccoYZQB4Ho8BwDYdv5YLFtz+gfRCjvYy2z135BMNC7HSSbKJNa4sEN/uhwjmgxF\ne6E53WtamIRMtCuseZHs5fwxI/uwNuSCIpNyrOCS4+T6RHvAfRGNyw+TbE1W9tbVlwDw1xEAjjs1\njGhZoqqjgzsUx+7195xo26bpXj7XdpqZQ9S+nAvOKB9rK7Uw48rHOGtQWdOSkdG+T7h9/oTKieN6\nQlvqyn3Wi1ZedFEOWDMjbbAD+1XI7BvLDpFM3i0J53eURAlGoGml5F32cZLd595Ln6b3Ejvvp/uX\nkI2u6bNRLzZwMQzDMAzDMIxesHDItWIDF2Os0RzYm+7Ubv0r30YvpmGayUOTwm8GQXugjq+GYRhN\nx7/bj+eWMyYPG7gYRg9Y4IDmkr4O5Qc3ZQczXO5gZxlnhRbZMg+gtX0dnMlaTDLYSRfKveYcd6/8\nsG/3lacj+54bt34rlkkulhZ5n291eU84d4qYY8k2hnOmbH0jMhGbIjOq6bcjB/gVMo9auxTJzs95\nGyepR8yAAG8qtkK2UGJKJqZi5yn3h8g4v4eYvK156Qe+A+KI763MvNP9aZKJZZzmiM8y+fVkcy/N\ncV7gckpWey1zvbC6yNwrzxGfZ2Y3KjIx9+L2NyvlpI0ppRwftzjKU76XV2YiszA2CfR5XPzOf4rb\n3TYvkzwuLxx34fq+Qo1JnAXOJC/5W9g8S54/NtWM85VQOTYRE8TcistpuVXuTtULeDMurV7mIUUW\nt8vvL8U8Sx5jNmlTJz7cvtp7KWHCqk32KXlcxEflRWprh6uHAwXIteHzQmZrvj6ly6OC+bjUig1c\nDIMwB/v6KdKuNF0D1S1Vhyc1DMOoi6qd6rX3YZVBVozxIwjDsLjUmBEEwU4Ahz/4wQ9ifn4ee/bs\nwZ49e4bdLaMB2MClfvIGJlVfj04/iN3Uq/Up8eOrzVhqgxUpt4PaFl9ybdb2o140fU+U6X7l1XVe\nuD7yDN+21TukfwhfAZDUmohjPTu4e+d8Hz5YnN3Z6X5GyQAez8RTWOAL89lib66LHLNZu+JDH/vw\nt2/G3tUeccAXbcwMecFL3/l4Nr3ipuKPUiWaxkU0KCdIJod7QSnH2e0vKOW0sMQi47DJ6TqIZdLq\nxBoZTfOxQamPNS9a6GOphx3xRYGhaXC049hKMtnOzvnXRouQ+vfkhh8BABwmtWEbLQDAc7g+lokW\n5usrtyHNNdNtAMDR33ifF653Sw5dLQ7uWnjgl2l9MefjmANhfEnZHmtrlLxM97ay+3LwDgmvzH0R\njiX/DZc6vDvuoXXpy3qSifM+a1c+7fr1KaW+DoRLyf8Tg5Y8TdSicryMaJRzg5Usur+34SJq7ArD\n8Ei5nteDfEse/lVg57vqbfvI94BdvwGggedl0Ey0xuXAgQPYuXPnsLthGIZhGIZhxOxwf8cB/Lsh\n96UAMxWrlYkeuBijR1ln+7RMnSXvYTa/TrOlpmt/ejmn9Z6/NrXVKlG+t3skCB7omGzSzMIMw+iV\nvHdLPe234/UmBTAxJhsbuBgG0bTBwaRT9fXwA9t2H7VozvnKds0hl/MXiIkYm4fc55ZPkOwDbnmz\nF608GZmI7frw/xfLZl22+FvIPkoyyN8In7NFnNm3U8Ozzixs05K3BbuwKsq9McM5TticSBDHdjIN\nWuVMoNg5f24paqM91/JtuGnDM2TnIv3jfC9iIiamRJvhzde2uqhDlz/r87jEeVm0nC0cpEj6fo5k\nmmkXm4gJYtLFjul5We01B3qlXc1hfzWb3kkb/OutOd1r10rq4X03pLZxX4uCAsg+13rR69uzJoEX\nXYMc/GHamf/xtZf1rdPetPGZr98CADj6h+yB7xBzsA+QTKpjU6yroOCe0/tbXiQO/Q8rpk7c/MPt\nZB3Mk1lRYvAh/Uo4yUcDg+R7SXm3yPvjYdpGpljho9EyuM+V43cQmYiJCVi+mW6yf9LHeLtMymiB\nCnbkmIcxbEIn54ge4zDcjyNHjmDXroZrXC5B/RqQS2pur0HYwMWohV6zzxeVrwNzFBx/yl7j4KYB\nd8QwjImkisz0icS1hW2lZe14XdOuRNtpwDRETZAx2djAxRgpyoYhTsuqDF9c1yCq6dqfqs7poI4z\nz7QhMXNY1nwtnkVUMt0Hyszhg1TovpyZTe1jg7UwEl6WZuKnb4ic81tox7Lb8VUAyfCyN+MvAQBb\nSEOx2Xmirz3vNRprXnNhgynz+8zbTsYziaKQ4Vl3N2MfkuzMhllX3HuBixM9h7oVR3zRDAE+uzrv\nK8cp2hUJwQwAU9In1gzJ+nFFxgEGROPCTvJ5v4q8TY6XtSznU9u4bjq3qtZEaWO1nHtNkzKjyPg4\n5lPLTu1tUeqTfTgAgHZsm7MyuW4ccGEROwAAJ+LGgOdwHYDkPfwE7gDgw3gD/l5f2eECUbCWSgsj\nLJoRdhA/RloJ0Tbc1OpcB2sMDrklawfEeT/WvMBrN1KalAyLol3RtLXZdwsT73M/yeV+fjW/2UT/\nM2gDpoP520X7c1Uru+0Qrd/hli8rQUhYA60ENTEMDRu4GIZhGIZhGEYvTKH+r+kJ/nqf4EM3JoGy\nzvz91MuMw0xRXUELqr4O5cwPs4nU1LJdmEF06y8T24bfl1vMMIwBUNacaqB9KGua6srV/btiJrFG\nk7GBi1ELTTfLanofxgVt8Dh8ZDCjmG7M7lcdWTP7sumGOPh+tpUtpznsU36W2IH8j0jmLG4+sPNP\nYtGtOAzA52SJ1iPzKTa9EdOqjecpP8tbkQlYwLkv5JeAzag0R+6p1DbixAYvFCfrOfK0PelMiDgH\ni6yz+Zjse3Ui4UqEOOxPsdmVmIOxqZjmiC/Hdppk4mCvZa1nkyg57rcVmfYryvVp+VTSdQBqPhzV\nSV67BmJKtplka5RyWu4XKbdRkV2DLNTn826f43NXxrLX3fXjfDxi/reKohy8hCjxxdMr745lc9Pu\nfqFzsPJlZyImTu2cr0TymXDeI3HY51wsYtKlZZRf1ic2/PZ2dpuYZd3Zih3ihaQJWJEJVo9o5m18\nDiTgwHdI9phbJnKnyLFTnzTH+ng7HY92Lh9ruzpomwQaYfPXuF2qb5R9Ziwccq3YwMUYecrO3Jf5\nWK4qBPGws703KZRyP33pdt9uyvuy+Q6xzRpkGYbRRAb5npi0d9CwNE3GaGADF6NRDC78bbUf8uP8\nQq3Dwb6q81eqntzszMn1vLwzsl0NWfod2k9mGxNZsF25L1K5L0t5KnavW14axqL/7trPAUiGjRVN\ny5WkUhDZJnjtimS9n/kuPNrMvmgwtGzxinaFfzkuuNn5TW+cjWUr62YyfWYHfEFCOEto3E7lWhfb\nAIB133PlWLvyrFty6GNx4D5BsrdSS8CfAw53LDOZrNUR+BdTC32cp33h8tKeFrKYZ1I1jctlikyu\nkaZx0bQ63IZk/GaNi2hmWGPlQh6/tc7HYT01E6kDJUw1ALQVNc3TuBEAMEPX+fDpXQCAKzccz5Qn\npaG/lre65Z/QNslMz5nktYz08kxySN74vaBMXPCzO9uKMtjzc58I7VscpKTItFg1aRaTUs2pnmWi\n7RVNLxAlnO8EO8QrprNF5tUxh9zyEyyL6kicv+1KuV/TNVtR0ILJGqQZ3WMDF8MwDMMwDMPoBTMV\nqxUbuBiG0RWDCnhQru22a6M1oPrzZ/v6S1xpGMYo0nUAjhHMOK8do73vjCZiAxdj5CnzoVz2Y7pW\nE6YBMuz2mX76wvuW+RFVc8skLI9absn15gxWNDOzRKZot13L0p3I5+BMI76htHEZrUepTnDdbd7W\nQzKQ7yD7jxvxdFQOz8UycYR/10s+xwnEeovNo0RGxWKzKHbeFjMqNnEScyIyKVvl1o9v8LZGEgxg\naWYWadgsTHLOsHmYbOeAAmvecDllxOmeTcXEDI6DDcgxvkEyOR7q+zuKOdjqdHlA/6UU8yw2r5Nz\nRTl34nq4LalPmzVlEzCpj++RDalt3BfeV3POl0u0Kit764ZsKu6Vq30jkvX+JVwdyySoAsvkWv4F\nbo9l59w9/Dy2xrKrN0TBFyS/DwA8t3R9pg/x5rvd8rO0TcyQOIeJmCnx8ydBMTSHfUae7Q65WLw5\nlbZNJnGy+ybfY+VMoeKgIHPK+5NN457IbvbHQW2J033i2BSn+5i9ifXIjIv2lXP/OhXb7ZaHSCbt\ncb4XcewXZ36iSb9dpbkE9WtAso/rxGADF6Ox9DOLX/TjkEka2EMbRW0OKozwqDHIQAHadS4boGFc\nz7dhGIOhF/+LPEdzXcvRzHdUHdqXdBujoq0y6sUGLoZhdIWq1ajhB3ZgP2JaGE5xfmVHVm0WU8ug\nLVqdT7e8SEK0/kOl/Zafir9ua6RBkYz3AHAjnnHLp32X3aw2z1Zf8aJTM7AmRcsMrzmda6GPBdYe\nuAn4CzSLL6GJV1Ejr81syfRPZuWnyBNeggtcpIbXn4+mcNe8+APfiIQyFj9ujpT8WqoM4DUtpDV5\nx5VbTZqK1ZrmQ7pXdC40p3uNSxWZ5pyvhaTeqJSbTy15fSvJNO2K9OVqZLg45Q/41Kpo5yXMxTLR\n/L2AbbFM7kPZxusnsCWWHXPT8xwO+YLr2OHv3kb9c9q4c16EG9xSZvgfpG2iXbkK+cjz/HBBuUWZ\n1CoOWdz5nVewr/rOEI2G5ohP5URToWmLONR6rPWl7fF7K6lJidD6fFDRIlG5q5TjFw3KvdSXJ936\nIaWJccESUNbKBCubDMMwDMMwDMMYFSZ4zGaMC01VrQPNyqcyilSVA0Y303DbRznxmWEYQ2PQpk3D\ndo4fdvuGoTHRA5d9+/Zhfn4ee/bswZ49e4bdHSNFVU7dg6i/qvomYSAzyGPsvm7FNIJMMTLOt+yI\nL06m7OC72y0/SuV+wS3v9qLY3IWdiB3bbvNJDyTT/VqylZFs8dspOcK2iy8AoLwmgHdO9+lUPOyc\nLyZOnLdDc8Rfk1ryvixSTKXEwT6ZxyUKHiDHA3gTsRmyX1vzkjMRY5MpOTYxEWPHeTEVO00yOQfU\n39gsjHO2CGzOlec4zzI5L5r52JRSTjuPWv6YdyOLZhbGgRQkf8u7SCZtcLtu+3mq7/W5edcV3+mT\n7uY4hU2x7EwiZX3Et/Fe1/XsSV2h3C7a9jMrrr5XydP9VXczHaKCkqvlE6n/GQ6Okfc8q1njs47p\nuRMdBRS9k8LPu/q+1CqoyfWLTcDkOLWs9S8r6zv2I3zKtaeZe8n5WE71MZOvCs6Ujc7VR92SA0fE\npmx0ru6UoADF5y/Z7iO4666v4OxZ7YXWMCwccq1M9MDlwIED2Llz57C7YWA8tCZlftgsI3BEVZqU\nsvv6fbToOVyuXbofhmE0m7qf5/T7XQuLHMt4QFJDn4refdl99qZk7cr61LHdOf7vLjzyyP+EI0eO\nYNeuXQNv2xgdJnrgYhh1kJt92MilrwFePJvI511xQpUPCHaClX05A7Q423+NZKIY4dlOcR5+lmRX\nRIvpG3x8XgkHu5m86a92KgV2xN/i0r9zuXV/4zQtnHRcJiY153tGNARcTmblZ5RyNLP3xruiWfSZ\n817T8+ZcNOW6QjtLKOOLM35nmXVfe9FrXNadVo5D4PDGcuhSjsMhizZJCzfMGiJthlLKaQ72SlCC\nQkd80WRwufOpbdwXDtcsWpMppRyjhVzemNoGeI0Ma9YcJ+Y2x+uiGWFn+hOuM21cQ81GB3JeOQkc\n4lqCMHxPiQCwuLQjXj/3rNPm8DMmz9OTJJPQv7/Wzh6IPLtcR16I34Ks8d1T7MTfDWr4d35/LUqf\nW/kVldBuSN2RloPPVd4x0baf/N+jJWvMhDvpvS0O+ztIFodkVrQ/o4iFQ66VCT50wzAMwzAMwzBG\nBdO4GLUw6Jwp3W4fdC4RozuyJhblTQd538S1GOUZPMMwaiMvH1RV7/ciUyszIzbKsPBnwMIh4Oy5\nwqJjiw1cjEbQ78u6KQ7geWXtB8nTSybprnFmEHF2eyRtqOPM1PJBwY74widp/ctu+cskE5OWe8Lc\nrlx2ReRpfvWcT0CyhCir/NX4HsmiDnIm+V2ukf/q++StLuZR/AbXcraICRg7529GlnVuyeZMbt8L\nZGo091ZkEnSR2p09H/V1acaf3FdmooQil5EjvpiSsZkZtB/f77olm4+lTcXYX1fWuS7xBS8y35hK\nLQFvbsXnQs4pOyIL7Pwu7bE1laxzG5emllyOZZr5mMA5W5xZWPjDXiTXaGmNd5LX8rO0ndnReXKm\nf82ZjV2kEyj5WS6QTOp5BHfFMnbKF04sRfWde5VupgW33EEFxTzwDpJJZngt27qYfiWCaMgK5yHR\n85VoiYjzSL/DCx3x034tzHJBu/ExkYO9XLZ7qJyYrvJ5yctNpQYjaNF/Wf+c+LyxCZikaOLn7pBb\n7iaZmPPF5mG+zYCtzGIzPr5GI/KbWaNz/p6fiP6OPA/s+sV62mwaNnAxjAHQpGADdfSlbBulQxQX\n7Ktvb+v77ND7Y474hjHeFDmmJ53Bq26T6cIx/iM5dQ5Ai9z5vVq+z9W2axj52MDFqIW6Qw/XOVgY\n9sBkXOl8XvemyrVoELKXZjmVH0aZqeTM0zKzydm33+OWPJuoODnHIY+/5qcOL/vZyDF91ZRXgoKU\neQAAIABJREFUfayfjqYneQb7FhwFAGzFK7FMQh5fTanh40zzrElJZ5IH8h3Hi5zPZX0+KzuzLqtm\n4NC47JgtzLr4qhxid8tSpDaZYe2PrPNxiOboNZK9mCrHoZKLghEIcoya87sWBvpSRcbXQNOQaBoe\nTUujabg0LZGmrZG+sObM3ZusCTu5Lqr8JXKSP6doTcQpn8NUs6O+sOw0hLxt0alLrsdzvl3Xma99\n98dj2Q9dG20/d9SHV4ZkIGhTI3xdBXouw0cBdkyPn/uEM7qmXfHrsRamw6BlWO/zMNyfHLTkOdhz\noAJ5f6VCJEfnyhPMSbAS2resIz6y2qn3P/pBAMDh0z7i14rc2O+hHWNNUEEggzhISn6xRjKF+r+m\nJ/jr3ZzzDcMwDMMwDMNoPBM8ZjPGmSaZak06nUwCKnN6ncv/3zCM8aFfE88q8qhovy/9vs+C4IGk\nD0mfZM5Tn3lj7L2ag4VDrhUbuBjGAGjSYKlJfQF0h9gyTrJFJh4Akj/OYg/OJmDiTP9pKqdl4hbY\nVEyciF/1ous+HHnNPv/yTX4XZw6z7bbvxLKNzgZGHJwBb27F5mNidrXZ5W4BgNYbLkmMZh6lOXfz\nW11Mm64lmTSnOOKr+yZEqxJLANjoTIz4OCTXx/rzr/t9V0W/tDMnfuArFFMxPrbXUkveruVs0ZhX\nZNI9zQRsDbKw+Zjsy9nqz6e2cd1cX5651xpFxqZl2seQHBuZioVu/di6H4plEgxhmRzx5bq0ydxK\neBo30r6Rgz2bmcm9y2aCEjiCy33t+Aczdb9y2kUS4GP7t5li+rO4W5EJsXlRsT9GJhv8crnJraoD\nx+SatbKDvYYWjIACGYT/Ot0Gsd0tF1monDctCIKc54f8sczgcQDA9KXeVHRFTHGfgCc2xeXcLsq7\nXvp3rFm/V0bzsIGLUTtFs1WD+NDu9FE86I/6qsNAjwNlZyblxzfz425hjg1jItEyuldTb9utZX1h\n+q87/b7bm7Otz7ZuKi5jGKOODVyMscQGCPVSdsYyb4CqZo0uYjk1mNlN215OLQHgVqUOmSV8XdnG\nM8SifdnuRc8fvx4AMH2rT4F+9YbIsZ4d7GVGukWeyDfiaQDADpoC3aqkkJdwtuumyAleZvHZ0f1i\nahvgNQQskyADPJuvOJD/3d+LCrLWRMIcryVVlITRjYMIAFh70WlhpvxPzLrXXP85lLHmnC/KJi4n\n2p+3Uv8DeMfJVmthiTUtBxQZn58pRSb+6BeUctyGnO8iTVheOU1bpISwDkl2fEN0rTgYgmjAjlPc\n5FV0jeJ93XbWmImDPYdInnYqpo2kHjuKWzL1zm+K7pezh66IZStXOaftJ+H5qFt+g2SfcMuvkSwz\nO09O3svy3milDysZatdRHPa3HNr7rnyUxIM5GmYO4ZzTAXbcv8e1y9qqHS2ET6W006J5XlSc5Dny\norwvXR0AEPznaPnhDz8SF/tf8H8CAP7x3O/EsnMfpeALgqZFk/f1fSR7sO22tZQdGk6N4ZATbU4o\nE2wlZxiGYRiGYRjGqGAaF2OssVjx+fRjytavGVx2ppNnAgdnTmEYxnihJktUy3X/zuK6kxqbznUX\n1Zufr6rdcVs3VOFMH3zGrWzPLWZYOORameBDN4ZFWTV7He2OY5tNxptBtAtKKuYUYl6wnCN7TKuL\nbeJb0YJzsogj6RdIFmc2D73saGS7cdkHTsailbcjU5rbN/xFLBMnZjbREROxOSzFMjHNYTMbcXwW\nMzLAZ6tXzcK07O5s4qRkaD/PGdcdq9y+7XU+kkEcUGDGBxTQcraIE/gUH9sqd2wXyTRJLIzYWum4\nIhMTMXbA52OPGotZrZlWCVoGey2vCt8PmhO/ZpYh9bEJmmaGJ3CABO1ayb5vk0yuFfX5rXWRocTy\njP8ylRwr7CR/wtmXPUNO93KvsUmi3HPsdC/1LJFjv2w/vuRvoK1zUT0cdGL5nNvnGB2HWBauJ9kv\nuCVngf8Ocun2fVqmvGY+Vj38DsrLZ6L477BPn7znOPqYmNVxEJJDqfKAfzfyvmKGRw7+eMgtHySZ\nu5bXf9jn61mPKDfV0sqsL/dlt+Q8Wfe2sjLhwawomWempRQwJh0buBgTiznOZ5Fz0uu5qPKcWmZ7\nwzAY0SKEbozs3zfVOuwn32Od6zZtsGHUjw1cjLHGBiP5dHKc73bf7tttqe1mNTIcMtTLYmITBtcX\nnuXVzBtkVpJndj/rlhye9Z+75XrSMLSi6fGNc17jcgqRMyprV8QpX2YkAWCVm2Lfhhdi2Rbnhc4z\n3bIPz2CvuvBKtKJpD9hZXAuxK9oI2le0K+dnvIvjBach2HzRxyBeWhXNpK7QztKvGVKHzOakul73\nIp2/027JYY5Fxo74EueAQ1HLL9W6VBlAd8TXstqL1mIdyWQfLXwxI+eRz7emudGc/WVf1sJIH1gL\n4zQtr1/jZ7DnlqJz+/qcVytJEAS+5/h+EeS+4utzyql1WDNzDNtcl/21ktDI7IgvbZw749t6/qgL\nY8WaFIHPjzjgc9jr3W5J4cXjjOtcTsiNJljSqb0nDpZ+1+UFHPHk5X1RzGVZA6GdA3GmX2xnt9H7\nU0hMCEl9D1GB3W55hmTuvcn33FdxOwDg7MtbfDnZ90lqU5zzZ1vKgJOgYwuXspsbjTnn14o55xuG\nYRiGYRiG0XhM42LUzrhmtTfTsyxp07PYYTRhx5wtn3TO18sahmEI2nui6LemrGls1Sa0dRLndtFC\nwddM2YAB/Z7v2rkE9WtAJljtYAMXY2IZmZfiCNGT6ZnmdB+bTChOrZxzQPIZiGw3Ff+AW3IeAckG\nfX/Ly8S87H4qJw7Sr5LNjzM7OrPi7WLEbObqOZ+z5YxiN3M7vgogmcX8Red4uoVsp65H5Pw6TaZY\nS2uiX6g1GynjvJhAFfxYhvPJOgDgzMzlAHx2dIZzeYhjNufyEHMidtoWh/3Z896+Y81L1FdBHOzZ\nLEwO8wTJxByLf50uprZpOVvYLEwz2RKZFtCA25J6eN/zikzq20Cy+dQ2lilO9yev9PZUa5ci2zi+\nf96ci+6vUxQ9QEy2+FqJCQ+b8ohzvpgzAv6+4voudzZBvG9c78qV8frZY1Felh+68dlYdmp9VPe5\ntpK/4wpal2fw5WyxhHnnY4rPCj3vklcky97Eehi2Orx/yjrJ1082t4sSoGRZ+t/KVnAnybTzTPXG\nfEIxsRUn+vdQfXdHi6cp0EN8//0/ZJsngU4W803B+DpkEgwbRgE2cDEai+77MFramknTwnT68bGs\n94Zh9EvwkWgZPtrDvsED6ORoX9XvStWagknXNgdzAJQ5EGOysYGLUTvj+vE+6sc1iP5nZwyVGdXl\ntpshpR1jLUw7WynPDspsrDimHmv5bTLjy+FWb3Xb2Tn//W75LMmcY/j0R70X+PSlkWYhDvcKnyV8\nETtimTjYi/YE8DOVN2ExlonWYi3ejGUym/4avMPr2pmoM29e6T3Dt5yO1BYBhRE+72b5T8752fSt\np7Mhjd90XtNryfv9BeegzUi/5si5W4IMTFH8YgnxPPeW8oXBWoYZRSZdyCZ0T2ot5NBFe8GhkjXn\nd95XkNMypZRbo8g0tPDFrMHRtDpOI/PGVq+50gIfLM1lNVyioTtB94MERvgeOdifc/cNO+mLpoU1\nM3JftWnGXjRm3/7u7bHsumuj+/T5v74plsHFpPhb3OBlT7olh7X9pFt+mWSi/fwa8jmmPPfybLNG\nISY7c+//17S/7Gjf2Um+F2f8PI1Bp3L57bhj48me3W4pmuO4npY3CQO8WdhHvWh6d/Quu+3z741l\nP+1S1/8+fjaWfePVfxCtXEP1HYoWz/zRLbHomRvcOr9L4wABWlCATudHT49QRR6a2jDn/FqZYCs5\nwzAMwzAMwzBGhbHSuASRXvUMgBDA6TAMPzTcHhl5aGZU3di59jNTZvSO2SIbhjFM8vK39Pt+6vS7\n0svv1aDyzGTauam4TFMZi9+TKdT/NT1WX+/dMW6H/gMA7w/DsHNiAWOk6BQXf1RedpM3kCrK/Nx2\nK2nH2P1Q87MsUhGph/OziGmCONuz2YKUI8uW2En44yT7nFu+h2TOTGLlSZ/0Y0X8qFveTqm1IWqf\nzb3EuZodWVuIyr1IJjqbXLIKNg2S9ZPkPD3rTLHYif/MBspWndqXnbtPbYjqEUftqK/O9IzMimaR\nTZwg9awiOy45TpbFGbQpAMCcM0wPnqEKJVn7aZKJwz6bj/kDyqLlXRFnenaSF9MyziUiVlmbSSZt\nsGmXZoIhh7uRZNIe/4puzpa74NpddcGb+r22aotryp9HOd8cNOF1J2PTQd8l39Fj7mZn2XO4HgBw\nDV6MZWIiNk05W+Te2HytDzDx/JHoS/jmnd+MZUePvC9aeRIeMUn6JMk4L4vvYMQhZVsiKEdn0y8h\n7cDuyX/X1vEuLtdG1oxK2z/2b+Hz8/+z97bhelTneei9EN1CG4GEpAhJBfsFKYAFIiBx6hhwsl07\nBhziOnHSoNPGRK5PS0vampYmPYZTmcRO05iEtAm+nMY1yMcnG/uKHV+uw4c/6u0YfxZkhQ0YnC14\nbYgkFH2CLIkdSev8WOuZdc/MM/POvN/v3uu+Ll0zembNWmtmz7tm1nru535elON03UKXvS6YFt/l\neH1XjH83sf0b/CGAIBQCAKv+taOcXveHjyS2y+SPxXlchOKXoajl+oKye9BaGIHPlVwu27cDmzYV\nVBkxLzHXJi4Gkf42r5GT3+1RMH+roPtRExFg6CuLzTbragKLGq3LjRKfOSIiYuhQZTGrH2IpVRfV\n0mOq9iHfWy9NL5F9XxRN1MrrkPu4q7TcUCDKIfcVc23iYgH8pTHmBID/aq3900F3KKIY2kuj3QzF\nwOh4YUYfZYGXnMG66Uw++N7ZFEljWY1VJzjKiiqtLCYeGcm0zTKgd/j2t1C9EkTMWdnf67eX0RJ/\n0y2Tv+7qsGL5ve1Xpo4BwMk17m3FK90vHXWr42vGwwtXAtg5IF4Crs9HWOne6VfOx8kDIhLEHCTP\nmc8FR+G8MEtpqVSCuzmYXoLzD+GccB2+/+w5Wq6mL3dgT8EJf+7swnBfznxecXprUsZyi1jKWPOC\n8H62DmmW32Za4Lw4z7ithYote4zr1j5OWEXYt3vwx4JHTKSH2cMlHo/9imeNy8nfiD0k4pE5SJ41\nsbGk8Tr/w/o2QjC2YMdzeRsOBXWMsYYL5N7xmZ8MxxdnT0D4vfHv6dam22rB9Ow9uMH/nqc0j2wH\nUOXVi9HJO6fKue1PjsLYl8uDdXu+zms/9MVk/yo8DgD4RfxZYrvmr5yNvdjNP3LbS//tzmCcUroi\nMtUb0u3aJ5AWVSlB+p2ReUdERNTAUMzZjDFvNMZ8zhjzN8aYU8aYtytlbjXGPG+MOWaM+ZYx5v9Q\nqrrGWrsJwD8C8D5jzGU973xERERERERERERERM8xLB6XMwHsAPA/AHwme9AY88sAfg/APwfwHQC3\nAXjEGHORtXaflLPW7vbbPcaYBwFsBPBk77sfMWwo876U0bjmSt6VqtfRmq7QSds3k62plo2IiIio\ngn6MIVUpvtyXdmhQdZG0V4F2209Up8UVUbi7L64wEEQ55L5iKCYu1tqHATwMAMaojsfbAPyxtfbj\nvswtAH4WwLsB/K63jQM4zVp7xBizGMA/BPDJPnQ/YkjQnlZ+523NReRFERqVyqdeOhv8OYm2P5C8\nqDizstAPOD+LHL+B+iF5We6lch/0bZzn/y9ZnxkTtC8JvjnAWAJPbyRukI9n/t6qK4JN4pSvt4np\nhQOOsrVocaB2SUDsEaL8CIWHM84LvoS3JPtr/U24AOE6hDrEuVZe9TwmoYcBwBrPu/q+D8rmdpn2\nJRSiNcQdF+oZU94kkHs5krWh1HGB0NEWEp0pebNwgL2wy5iBJuW0jPQatDwpYtMoYFq9Zyi2Hyk2\nPlfO4cv38fKvElVs17jLNK/9nV+lCuV+M+XuMR/pvjQVFe3AeVeERsh/Z6GZsSCElFuPpxPbgwd8\nBkeihS25zEXTHyYBgESUgulhsv8A2a5VbJpQhpbJfcpvCylddcbYFnmhPIYnQL/6+akJm9yrc0KZ\nN7/vLwCEsQMA3gZnu+brj4dzt/gt8VmW+ef6b9ax6oTHQ/nFr6qTCn5flJ+zrfR+WbsV27dvx6ZN\n/71SuxHzA0MxcSmDMebvAdgE4LfFZq21xpgvIaSOA9xr5M+NMRbu9fLfrbWPI2LoMMqB64Jh9cyU\ne5qaqf+3u1LIgfSi/DKSq2QRERFDi26/J7qd1b6dtgXl3hxfdtFwvFPqQt4zVd8vc+F7IHpc+ouh\nn7jArZEuAPBSxv4SEJacrLXPA7gCNXDbbbdhyZJ01OfmzZuxefPm9noaMTRotYrTzrFutT9MSK+M\ndaFC9pA8VPxCSrU1gzzEC/OQMiHiANFsJm7x8jB4tVdWhm8i25Ri2yB9o45SnLJg6TK3Or73469J\nbDvf5QLTj87mJYuvHvtGsi+Zzc+loe2kH5Jbrc6LF4S9HDvgxAPYk8LB9gIJ1l6jqPVwhnZZ+ec2\npA/cl5Wvuv6feeBUqOiw37InQySP+a3DXg0ox7PlNFniBYptSeYY27Q2tWB/fjX4lekTJKV89EwX\nEM8yxyJpzPddZIlZUEE8YOxFEwlslrMe8y4rlkgWDxxLWH/H/03ZsyZ1cxC/PK/s0zn8ov+b76Fn\nXYLtn6GC8jtdpdjOI5um6TCt/I7Fe8C/58Q7m6etBoEPpX5l5b5qVvuic8rLNSqVq1pH6di7qBEW\niC53/Xvt+8If5mI8CwDYhLBO+5YDfmB8MFTz9b9222voGT7bywx/Em8LRhFIqDBxqqI4qd9T8ZCl\n/86Tk5P4uZ8L1/H2t78dhw8fRkQEYxQmLj3DPffcg40bNw66GxERERERERER8xrawrGjisVELhEB\nozBx2Qe3zpbNwHUu9FRXEQPCnHD5Eob9eoahf1Xzr/Q7mDUiImLuwI115XlNijLed7cP5ajaXl1q\nbTLOrist1ndU+bukywr0cwZJ5+sIp6P/X9Oj8PXeIwz9pVtr/84Y8ziANwP4HJAE8L8ZwH8bZN8i\n2sPIDUoKhvUaymlwje40klAJqD6he0xxwbIXmnKMX8pCPZlRricV7O/7IBm8r6VDH8jUBeh5Jz7h\nt0yB2eG3HMQ/4bcPBF7Hgvd57hL1ffcuH619PNB7lpzn6FQ7qaAETzOVR2hFHFAtgd5X4rtU7iIA\n6RwwQjPTcryMKXSv51MB347exoHhQk9i+pjQ2pjetn+ho7ydefre0KBGC5P9JYqNKWXCvNKC48uC\n81sF+C/JbIGQR4bPlWB7Ckw/4Y8fOjufzGTfgtXJvvytOEheo9cJjYtpYXLvOeheqF/7kQ+e5vws\nWkD/3ufcc7DywhdyNnkeAWC26QPxdyAP/u1M+O2fk00Srt9Cto8o5wqFNJV53dOEpu+icasBoB5t\ntU7Q+KBQhbZWqHDJlC1/n/cfXZGY1o67HCzn44fhXPkp0u+vITu/Qo38ktv8811/Emx/A9g1Gp+y\n6Dq2FZYphpKjZsj/hhHDg6GYuBhjzoR79ctwdaEx5icAHLDWvgDg9wHc7ycwIoc8DuD+TtqVGJcY\n1zI3MAweiF6jrvykQHu5V3nh68c7y+hsLu/o9IiIiDmGZEzQYmHmCYbtwz3rTbdHq/WxrtekKEZm\ncnISk5OTIxHjYk8DbJ+D5e1QZGEcDIZi4gK3XvoVANb/+z1v3wbg3dbaTxljVgD4TTiK2A4A11lr\n/7aTRmOMS3cx1yYLo3A93e5jpfrE08IyptNKsKV4YTTpY4bUcx4dmyppXwvA10ij4hm6m8qLZ+Yj\nyNsYssD9M2SbyWwB7N5+gdtpkO6veFp2hGXjw2e4DOjHzghfA7N7zkYWV6x3msu8Ei9B2F/H1Ynt\nNd7TwpLL4rlhKWVZ5WcvjEgoczlpj+WVL/cptvchrO6u8KIA7D1I9o8jQMs0L16QE8ijLCA/uw8A\nFGCsSiqLV4U9L/In4n7+eL598a5I8D0A7PJeFc5qL14qvrciFz2dqDsAi32gPgfsi/gC1ydeMfae\nSN38dxH5aa5PPGDsHbvoQvf3ax5ohDaWunMOP0buRfntTART0oWPkk0yrmvB95/nck23nWkoBQna\nWEAozj1VvWzV41UwsPcBe6K9/NDF488mJnnWWGzjRxe4r9oz3xwEM/6+9x7/zur3JrbEa/e2zA/s\nQdRCFa+J7q3hRbCbU6wAWVCOMS4RWQzFxMVa+1UApfNHa+2HAXy4Pz2KiIiIiIiIiIiIiBgmDMXE\nJSKiVzSvsnqHNRdLREREREQaRav5RdSkquN71ZiTdjAf6MtVMWxUuG7i5ALgZJ+/pk/GPC4REaOP\n+f5iYFTPR1D1nnFmas3Nn8+7kFBGMpQQ+wRg3tYIhheVwP5b/fZepSsc9Lsqc4wpY0Ip06hgt9O+\n5HZ5L9m+qNQnAf2c7+VbfjtBVAtPs1n9C88npv0HHPds9lCgBmGp4y6tXRO4Z0K72oWQjv2lWceL\n4hwwQjXickIxYrrQXs+pYmqXUEr2UcD36UoAuVDEmJIk1CYul/SJ4scXCi3rR7li6cz1WsB+Ugnt\nZ3OwaOWV5N9qOaKqveqPHxzPF5xVEr4wNU/y8DCtT+4PiyHs9X8PppTJPufIkcD+k8Svk/0mLqBy\njjYmVDWuj//2iUgE435/TRNka/jtfWQTphv/duS39n6yyW/8vAZKIbTNG9Ll7IOAoRQiqhiHgrkS\n0B2uo0m2hrNJ3A//Dfyjpv3uH8F1ia250NWx+qcCfeyfXPEpAMD/vf2eUN8maTe07xByx1Tpf9H/\n65wbEVEVceISMSfR7gutH16Yfq3wVak7GxhpbaPnHwPG3JVOVBkRETEvYS5HeiGCj9Xwljtbk8o3\nutC74v5ofWqrTkVOPmmnRQxQrzEoRsIoeqlODcDjcip6XOYnoqrY8KCXA1RR3aMyKDI663N7amDF\n2ZEVL0tmQmIfzLycxVsz1aJRzdMiuJT2Hwm79onMRExWd9lrIudOk00kkinoPlngZvVb8bhcRy/0\nD/rr5Qzj33Sb3UvDKnlyvEHlznCr3yfWhDfQ49uvAQC8bmOQPh4fcyvrLKXc8CukvDofVvtJKMDj\nVcV7wCv2Aq5P5JAXkItC2thL0fEiybyQg7a1APzlyjFNMEgLrBe8xm/ppf2qdzIspLoOrnZeibNe\nDteoZbof/5ELXn5hPHhDxPvEnhTxZIxTtnoRQ+Byci7LF5/wnZWgei7Hme4lyHq5F0DgcxbS31T+\nRrtmgwyzPCO7n6Znznv00KS//YTffiCYcKPfshCFeCFZDlzzXIpX80Wyye9uSinPcshybkoiWaCM\nLQUoGp+673Wuj9K6WeZ4UaNYteu+Jv2nAQDYfVP4O+9e7PfZkykgIYo/vPrfuJ1NVdQli/rdmaJk\nPUzj7W9/+0ioikX0F/N64hJVxSIiIiIiIiIihg0b8LnPbR0JVbGTCwxOLKiRfKgrbYoI7/zDvJ64\nRIwuuu3GHgaudNZF3uoa++VS7yTvijHNdKLKHiLmh4mImJsoyvXhjlXP3p4/z6Gbwi3t5MvSzusX\nyu5t79uOAjkR9REnLhFzEp0MgL0ePLX6u/XSqtv3llzwhGetUzdyQbIP8XUoHxNJbpdmsMnEhoPe\nhZbyPNnu9uc80gg2oXcJi+qDdOxRv2UqyqpGujwQOPa3KhQwpsoIfYa558IS+rxSjlg7Sd4Yzh/j\nu/WDZy5JTGMTLwMAvvf0lYlNcrtwQLwEY1+JQCl71mdc52B6yQFzOp0rtCfODbLBc+f4XAkwZ4qT\n1Me5Rpa+7Dl0GlWFA+a1LPXCODtdsXF9njZmkxwrQT1/dqEzHiVKolDaXj075GKRwPqxBSEg/vsL\nXQf5GuUeHEU+AIHzrkjQPVPF5FwOzv+G52exTc55gvK9CHXvJaLhSb8WEUVNRAMOvxgC8RMyzRm0\nAvsef7PupAvQBCaE5sXP+jrFJrgKsB9zuwkNdIKOyxjAvxOmZia2/MRBz++BxJYdr4qytxdTndpH\nN98LxRMluu7ppos5ZCETGVuY/vpiKB/g7wfR0R4/9vfdDtN5VZpeMXoRO5RvI05eIsoRJy4RQ4th\nDtLr9opcu+eWHa97z9pZeRvkal1ERMRgkPzu++RNTbfdfvb2VpLK2jmdQhUS8BO+VspdZhzpSeEQ\nodN7Ngwsh27h5IIFOHl6f1PZn1xwCnow4dxHnLhERGDwEyOt/Sp9qic/2ajTJYfpu3wbnPW4mS8n\nK3vH6JiW4V68G9O0Qjrhz32AymkrvVt8fbzaKKuMN/ljd1D78lHF/XgsswXC6vMqupcH/ZY9Bp/w\nWw7EF0/LFNkm/JYll0XeeSnZ5DpIAGB26mxnuj4EaM8cdcvfy8eD7Qe7nDtndk3wKAh4dV5kdF+P\nbyc28ZZI8D0QPDgcsC9B4isogHwtdgJIew/2ne2i6Vf9LQXRyvuUM9xzxvrQiENeOyCFrGyx5kHi\nAHYJiOdrlD4/i4sSm8gRsyhBkk2cIPeUJY3Fg8PStFIPe8dEGIFt4plZSX8r6cs0eWEuwrO+3vCq\nnj7qjx8iTv1S72mZIdsfedsDZNMUvMRryb+rhxQPgEgea6v0mi0ZOzjbPXtG8l6VbnjK63wQV6Vx\ntdOPbF+S/ilKYqoXXspNkVHETR7SpZQDFI+VjIdT+UPd/ltoaHVfIiKqYl5PXKKqWERERERERETE\ncGFychKTk5MjoSp2asECnFzQH4/LpydP4NOTJ/Hy8N+WnmFeT1yiqthgMejAvCpBlFX7VERNKGuv\nzN7rrM1hla58BZTriStjERERdVCXSqp6KErjXnrTD72O3r2v1HfDovL6u3FfqmIQHhJZUB4FVbF+\n4p2bT8c7N5+Ov9p+Cm/alJe+nw+Y1xOXiOFG2QA56I/oIrd33fN7RVPoJX84yeysfQz1d/69AAAg\nAElEQVQwLSsJFqXJUZIZm162ElzKAfMCprZIPoNU9m1f91LleZBA+CmlDubmS04LDmIW2hrnrhCK\nGOfAkHO03DIT+S6l8l0IjtC+zwFzpLEi2J50m7PeRYHzZ7gX1ktHQ4D2unHH+dlxlAL7x13wPtOP\nNnmeHFOchJLEdKt1nhbGweeSn2QF5RoRHPyxQB87RyhntCpof9xtDb1rX16Zz61y+kmXW2XfeODp\nHfNCAhIwz/lUhJ7FuWokiJ5z0BxK8fQc9vnr0TLTM8Z9u0wVE6xJVAeA7+LKVPsAcLG/t1+ZnUhs\nrx/7jm+3kdhe9bS2vU+/JrEtWO/oZZyfZXHD3fuVG3+Y2PZu9+dcRjf3S/5+8GXL83cJ2eRZnyDb\nFkWcYpUcC31O0TsT3OwT2Ta1g4RtbY7j+SB9Rnmd5edWq6MOFApWhYz0AFK029BnZXyXMZfzUE34\nLYulJMIoZEsovlXzuDDanzAN+v0dMdqIE5eIeYFhyALcznmt+tntclXqCOhnMrKIiIhRgXlbF+ro\ncOxMo3/emnT7+XY7WVQaBjEUzdMz32NWTuK0VJxcf9qcv4gTl4iBYdADXLsB8d04p+zcshdbp56e\nUE/D72l9r9inlHfFHz+Pzw1t2Cd8PRJwqnlm2JOieSZE6vhRsskqYiIzTN6dW5TVRJE55lVoOZc9\nKRKwzwHLgrtpXwv2v0Wx3eu3byCbBOVzG+IYUaSFtVX32eMh+HzGu6zOGn8FWXAw/TRcwptz8VJi\nOxd7c+eI14DPlQDz58lTIJ4Zzha/YJmvb1n+OtKZ613dEuAPBAlg9lpI3dL+DNYmx1jCWSDB+xK4\nz/VpAfvjKUGDcG1Z7McK2nd9Wkn3UerhvifS1WM7EtsOXAEAOHQgPIjLlzkRhLXrn8r1mW07dyl/\nZ3GATZLKwc/47TvoAuRZ/6ZycZrX8CqlnCacwUh+x+US6mXHur/QVOzdqV53NW9N1Xa1frQ1ps8o\ntinFJmM0U9BYTKUE6t9FvNY5b01ERG8RJy4RERERERERERERbeAkFiRKhv1rc/4iTlwiIoYYVV3w\nVVfqsvWpAgUZuc7KnOyydmNW+4iICALTnqp4Mupkui9rr1dJFMv6UKd/5ef3h57bixjJQYvxRMwd\nzOuJS5RDnj8YrUFSXk461aJquX4E6icQ+sEU2bRge6EVTNMLWKglfK5QGGYawcbHs+WSupSs0JzB\n+w6FLiH0GQ40vk/J/p0tz7iF9p9X6vuS3+5AOSQAeopsQikj+tyRpZ6KdChQgxatc5yz/QcCZUvo\nTG9c9rXEJsHkkpMFSNOnBMLZXk6B+BLsvpDoY0KFYkrZ4gWv+PYDtUqC489dEKhVJxa6NphaJTQv\nDrY/6M+VdpkedgjnpPrmrsedywIEct1MM5O8NXsp4YzUzX0S+piIA7j2TvpjgcIn5zDfXcpxHpfz\n8YJr93igsh2ddaIAu19sJLbVFzYBADu/QDyudS4/y+4vhHYTuuE5wZQ8N59AHk/RvghMHCTbTGbL\n4N+1/P6Y5inPMH9k9zlRZbGKYjvg8bU67asYZZOP9DEncsDjt+9Liu6ljFXT1Ra8mM4raPW+yOWj\n0cbILmCU5JAj+ot5PXGJcsjzB1VXe9pZFWonMLHuaiO3061JmJYIrazdiIiIiE7Rjvc1OwZ1R944\n1NErL0yn6MbYq0vfB9SNrUnKtpBrrlpP0ftslOSQT2FBKklsf9qcv5jXE5eIiF4jHUzfrHhOw5ev\nVq5lVnvNM1Py0mFqWBFFIfuiT9rllVWRMuZAe2mXV23FM5IKzvf7vOKrBYGKh0Xq4LZu93XcSzZp\nf4JsUyX9ZMii9xTZJFCfA5bF08LeoI/6vtxHtpSss4esVr9H6d9lZHvSeyNI/vbYETcTXbrsUGIT\nLwMHnItHgW3iDVlLN1wLUhePB2euP5HIEQevzQ4vC8xB7+KROUjKCPKyZw/FDqzPnSveF/EMLUW4\nRunnapIlFi8ICxCI9+Vxijhfj6dT18DlFlH7GzANAPgGrk5s4kHRpI+/dPQtie1I03mdVq9/PrEl\n3hJ6vsf/lfP+HD4Ufvi7P+PLsXzxjD/+RbKJ6IPmNVEli5Vy/AzL7/M85CG/NQDJmDKlBHxr4h28\nOr+hkYh2VIX7yG4qR1pJJBcf6xbqyvenr6PMu85jr1JOxqqZtM0e7bEKmeY9BwBl3AC6JywTEREn\nLhFzGt1O+jhMA26ycsm6/CxR2WZcSZXzzDh0KlhERERERfRrPB2UXO8gZYJd261jYrr9N5iPCYsH\nI4c8f30uceISMW/Qy5iPKoN0/VW/ci9HKXi1M1nZVFb9xlv0e8PW3KpoKcVsgvZlZXYL9UVWBXkl\nV+JYpoK3J2mD67vU95U9KNfKjq+DJV2F738T2cTj8RDZyvj3LAcrcQHsSbnVb7dQHTKh4/icCb99\njGwSWzBFbYgzgldPr/dbanbx9S7u5MifhRiS1e9yK/orsJ+qc54JSTAJBG8Ix4m8DQ8CAMYoASXH\nsQjEu5CO9XCxJbMUkyLtcjnxyLCHQqNXiFdF+xDgmBWBeHJ20kxa4nI4YaS0z/LFWkJJ6TPH7DwI\nl5iEvTpyH8VrAwDP4mLX/niIC5J4JPYS7RZP2XnhnmlemOSSPks2Ob6cbP80dxlp2W6BePTYuyKe\nRl4AEc+IlsCwpefWH0+txOc9IpVjKXL03YZSuj6q1tOrD/B0+9VkoI3x91TzPqsxLuyh0SYx25Rj\n4Zxq78xtPX23RkRkEScuEREREREREREREW3Axbj01+NyKnpcIiIiOkE/3OOdtlFFeECjieUoBz1U\nCIqyyRERcxN1V+O18tkxUKNitQq61+L26npxOhNkaaUWGQHwPd5VWi5i/iFOXCLmNLSXSt0gSu14\nP1zi/DJV25OM8ylsKwhgbShlkaY9Cb0sVa/ykhX6ClNLNDlkqY8D0gVT1B8tVkZsHAgsAftM/XrU\nb4UixnKwEpR8Hdk+6OvQZF73KDbuu5zLfdekZAV8XdN+y9Qzid9muVqpepJsU35LAftHdniK2FsC\ntWv/UWdjCeLzx53sLlOihCp1JWkzC32rQdLHksGeZXylHqaZldHCOIg/ULBCn3d76he3IeceIUqZ\ntCHB9k/7AH4gSAt/G69PbCJKwKugL8FJD19MtDmByCIDgY6Wppk5Stf3PRXMnXM014aAaXMiWf29\nJ69MTGNXvezKHadyQp88QhXJM3k92R722wmyyXPPQfxyLotOyO/p3kawfd5vZ2jsk98M072mlTEo\nGT8U+liFjOo5KpQ8QsfyiyyjSUOqn3el/P3UAECUMcZ0UxF20ShgZBN62fu5oq2wv5CpmyiBCZ1X\nCfyvOombT/EvEd3HvJ64xDwu8xtFL8JuJHrsSl/alJvUvSbNtuqKiIiIGDTycsjDN4nptryyKjt8\nLO8tUs/pUtu9mmBUu1fT/t/xnvShmzg1gOD8U7TYM98wrycuMY9LRCfo66qRl7dMt98AkJFNlhU0\nkhotn7TQSql4BVITJkVW06/spdqVIPVHkCrn6msEmyaz+pDygp7wWw5wTzxBZJN6JGD/mOIF0oKd\nW3mVBLdTn2Q1+046rgXTa9fNnhaBrFbvoXKSNHA/lZM+c/LKd3ivBSWgnD3D2RYtDg+KyBxfjW8k\nNglc1wLdOYmjBM6zd0W8IWMkfSyeCX5xi7wwe02W+4taoHhh2CZJM7VymsdHrmMFeYvkGlkIYAPc\nD2IvQtLHfb6tc7E3sYlXhz0u4tVhSJ+eJS/M7l2uL2vX0ANxhksYyR642QfOdjsTVOHtfstS2OJ9\n+SOyiSdlKdlk/6NkY6GKLG6nfekDezL3A/ZjgHmkEWzifeHnWp7hzCKLGzP0pks9CslqfvG56Y/z\n/Ae89iHc7bG6umfB9SUlaHKsfYpaQNWAeC6nTHb8uPTaX3gmMf3AfDJXLPvuAXovMW3tnwHASORx\niegv5vXEJSIiIiIiIiIiIqJdnMBpqVxQ/WpzviJOXCKGHu1ksw/nNum8Ru32ihOe1Q/Q1ANJ6was\npvvSyapX1ba164/Us4iIuQ1jmmlZ9Vrnth5bep3jRBsrOxk/23kPdSvLfJX+tC5XP96mVZsxViVi\nEIgTl4h5Cz2b8eC407nJDAfOAygMsGekAmiVvAtVcOyuvEKPRg9h3B1sgR7hz2EKigTMa8HxWjkt\nwPc8+ru9mDnG1C7p0+0Nsvn6bqByq/z+fUrOCqa+CR1tgmxCx+G8GNIe3ZMkfwtf9zZvmyKbJFdn\noQChDjE16ElHEVv9VsrG7mlKy5cFntla3+ByolEJfWsddUZoWS8RjUoC3DnoXfLBMI1KAtbfiK8l\nNqGoMR1No4UJ5euVhCMXgvc5wF0oX7LVVjfZJjQ37qfkpeH212Fn7hqzbQJA0//2mKIm92r/AUqo\n0nR93nmIeFryjDI9cnHmGAB81NP/nqSAfQHnbJFn4/Nku9FvmR52t/LRvKXhtg9QOekDC2EImFIp\nY8Axhap1jAPDlQ/lLioRpjOwN4sL9hmlkyBtzKyK1HhcVlDPxZJgS8Nt77TB9oF8sdfaX0YzpfLQ\nffSaZhYxtxEnLhFzBp14QPrdl3baVj0fZckgO0AnHwTmbd3rR0RExNxCR2NLSdD4ILPUF/Wjddmm\n26GJnRZP0m/0Q95/LuEUTleT6fa2zRicHxExtOhk8OzGyo6W4bi9eqplR9Zfys1cf5JJi6o6oyBV\nTupLr8xp1DhrG2mlMgnip2zYyTk3NPJtcLZ4rZ/SrwfyxXAv9fl25bg4DSTwmT0kW3y7G8gmnpZV\nyOPT1JasZmsSydq57C0SaWReZf6I3/IKp2Q253MFvHIuAdd0/SKnK14WAFiyQtNkdmjigmRfPCks\nXywekjWUM0E8H5zxXaSWz6Xs86f7zPHs3RDPhBZEz21IID5nqReZ4d3krVlJwfNA8J4AITiexQHk\n+ApSOdDKiSdlH7k01mB3rp+LfJ++cyB4ZsbOcG3MNs9ObK+92gU5/2BXuN+A4kGRZ4ilj+/35bTF\n7g2K7SnaP6TYxGvIXj76jSWB8LLQME3ltBV7CSpXxxGCJod87OZ8ua6g2JusB+nnbVXR2Ud863E2\nD014QHk3yN+PPWbyN5iggt7TsunCINTx+HuuAZB5Xv/+7xT2KE5kIoYBceISERERERERERER0QYG\nI4ccg/MjIiLaRCdB7tXPD6tvVQM+u6bpPw49SSQK+OwRERFDj+S3e0N3VtHVeLi6fcH8WNV311t9\nzMzdW/ZmdenvVxfd/pvNt2cgon3EiUvEnEGng123szMX9+dmJZC1Fbbl+6cmI7s5KZ9gQ+hHyO1S\nsVl5Uc6kbS5Pw135cg8pFDAtEJ/7LJSpQ3RYKFVavolsQD63cSvZhDYzRbYXM1s+l6lqUg8H3QuY\nPiYMIz73/Zn2AeDP/ZYpYLLPQdtCHeJAfGFxfDaYZic8PYlyu6z7Vy7QnHOOSAA5055kZfBVysWi\nBb0LvYxXEoUi9jwJRRzL5Fhx3T+U64sIBMxgLdXnKGAcxC/0sn2elub66mhUkmdGo6VxML3UxzQ3\nob61yi0j9LGLvRABkM7VIjjyZ65/Yze+nNh+8HHP87o2BECPrXLHZ/cESlkSnP8HVOF7/ZafOXmu\nbiGbsN9SwfSuz6lnXSiIrQLs5bfACmIp2ljmXF7EkDxLTBnzgfpmvCKFtQKKqFXD+IGbFg/QxmiN\nhtdUaGxKpnsNyXNA9Qo170Wq87gb9Nd7aicAPN5wiVzGfA4oAETCjKiKkwPwuJyMHpf5idtuuw1L\nlizB5s2bsXnz5kF3J6JNdGulpmgS0a4EZLcDHPuhoFM12D8V8xIRERFB6LZoSJGHolNBlmGc+EQ4\nTE5OYnJyEocPHx50VyKGDPN64nLPPfdg48aNg+5GxICgr4zVf5l1ohqWkx1uCSUgPgVlNS+VJb6R\nKadIlnqPimtDuY4Nyv3xkp2pVdYJv+VgdllBvrcRbLdK/xQvEXtrZGWYs9CLt0JWHZ+ieqXd+5rB\npkkVi6DAFNUrXg5u/06/vUORnL6OTN/MtA8EKWXNI3QO2SS+noOx/XWvfl+QPhYvw6Grg2tGAtwP\nkbtGVlcfx6acjeWGV3pPyjEK2N+LlQDSXgvxdHwdVyc2kRTeQMv00odpuhDpnwTf8/7X8MbEtsm7\nHNjjIfU9jfUA0p4c8cJIf/k4e2bE4/MaOlc8KcspiH/HgSsAAN9dfEW4xjF3jUcXL0pss4udB2X2\nGfKkiDfieHBpzn7eH+fnQTyJ7ycbe18E8nxrvyEWwhBPJ/825blnT4o8z1uonHgQ2VuqrfKL12Qm\nIyZyNOPBVWWTi4U/NOhj87YRnmjQ2JaIFzTrn3ss7GbvRWrshf+7fDz8f8k694dOSX9/yY0BszcX\nB+QXodt/i2x9sqC8fft2bNq0qeCsiFGDMeZsAP8QwLPW2u+1U8e8nrhEREREREREREREtIuTWKDm\nlup1m6MAY8ynAPyltfaPjDGL4MiwDXfI3GSt/XTdOuPEJWJeoJcUgXa8NXlPRp1AzfYD4itTwdqg\npUX6WETE/EPVQPO6Aemd9ceh1XjcLp23yKPe6XulzrjbSlzBmLuAbaPqoYqYQ/gpAB/0+z8PwMBF\ncd4Mx2OIE5eI+YduTELK66j/stXqKw/Iz9MgUpMMNe+KlsNACc6XfVYhk5cd00OOaXQOyd3QCKYU\n9cxjg0J/mPLn3EnlhErDQfcJVYv6N63cI2EiMVVlAun+ccCyUGSYKiP0LL6eqUxdDA5EflT6S+1f\nmznG9TEtTFNlk3IsFHC/336LbEq/Xpp1tKhzx0J+E6Fd8Uqc5EnZhMdzNg5IF9rYC0S3EjqaBPhz\nGxfj+3SuC/LnAHsJlGcKlpzLuV1klfIiooUJNY3pY4s8R2Yl5Y8RvIDXAAB2PBcoMOdf6OhgmiiB\n0M24rRSlbNn+1DEg5Hk5/GK4F7jCB+CfQeHMkvWeKYacq0Vwv9/+KtkkAJ+D84XuxUHWE37LQg/y\n2+F2tzTy9clzyPRJ+f1p+VlSdDQ/FnDeofsCjSucK+MIeo5OaL29TECcQ0YB0tHrsuN3h+8xTQCB\nREMOH3F8w8NXEO9QhFEy9F8RcYmohlNYMIAElKPhcQGwBMABv389gE9ba48aY/4CwIfaqTBOXCIi\n0L1VOu1lWJR4srj+pttpQ1a0U3Q7qDYiIiKiLrolRNJu7GKvg/i1d0G/PFJVIPc/G4MUxQ0i2sAL\nAN5gjDkAN3GRpY9zABxvp8I4cYmIaAEevLsxMcm+nAqzOVcO3mSEVbxc4L8iuZkN6ASQDs6XiUzK\nY9CAfSITkCtBxNOKJOcdxdmtAQCX+j5McR8UD04S9Eu2Vd4m3o1HGuGYrD5z+SR+nPqkUS3EI6QF\n099ItueRx0f89m6ySV94tVrqpqTVYw0vnXsGBXz7hX8Oat894046tirMNNcsc94FDlyXgPj9lBle\nPA8NNBPbTi9RLFnjAWAHXHD6WlrGl1XFWZJSFq8JtyvtjZG4qsgMT+Arie1xr7TwJvrjv+S9Pv8A\n305se73X56gXDwjireG+vPPCP81dz2Ly7kgdLCIgXqKjCEH3u59293Zs/TPheo466eOVF4ZrPHrU\n9eXIw0G2OcFiZZ8lsyf8lp8HeW40rwl7SK7ytruVXB7svZNzeAFEfsdaYD97BTR586TetPx67wPs\ni9voBN366C6rpxPhFrlutTz/raZC+QA/vrEH+tqG274l08ej6f/3Q70yYl7hDwD8f3C+5x8iPLE/\nBV14vSXixCUiIiIiIiIiIiKiDZzEggHkcRkNqpi19sPGmO8AOB/AF621p/yh55AmkldGnLhEzEm0\noggUucL5mB5DUt5WOzDmLl1iuENotK/EdkxZZU31qemPN8qPR0REzGuYcRR4RovyYoWymkehyIMx\nyMzqdYL4tevpazxNTXQ731hERBbW2seMMU8AuMAYs9Nae8Ja+xft1hcnLhHzAmnaQrPweDc/yPMv\ngpvpWMO3pwfqF9VXFPCao6ulJiRKcL7A519J94UoB5IFO9VPf5wnWy9mjgHhA2ZCoTVMUHWP5Lul\n0uTExpMpjQ4jEFrMTelj9n0Zipz0idd+xLYfeXye9oWKsYXakCBrrk+C95kGJHhD2J39iKOIrXzf\nDxPb3u0u+PyFAyGAfPV6x1HjXCcSuH6UcrFIhvtzKNB8tQ9Y52B62WdJz5lZR7daNBa4JAs99Ytp\nYRKIz3lUJJieKWXS1/1YkTuX873IdXwNP5XYhA4mOWhmFLUDvu6DPu8LU8VkhVJoZNz+Qs4X7p/l\n/Y3Qz+XjLgfMD567OJSToPxLqBNn+ID9X6MfqsRCc/4hoY9dTzaNTngQeST5WdK/P/tERtlPm0BM\nKwIcWs6k5Pen0I+YZjal9K8U1WI4OqGG1afuFtdRVE+nH/n5yYwmqgK4gH3lb9CSRqzc5zv8WH4H\nn5t/15Td+zi50XEKp/XdA3IKp/W1vXZhjBkH8IcID+VFAJ4zxvwhgL+x1tZOIhQnLhFzHr1aUaoy\nyelmsHvZi7iTl3Sr65hr3pUoQBAxF2FMM62gV1ZujmCQXphRRBUBgLJ72isZ6Ig5jf8M4Cfglisf\nJvuX4FLwxolLRARQvupWvqIUjgXvhrLi1Y76CwW958CrnUlgeqvJiLJKp8kcJ7amcq5WH3uE/Dm8\nujuT2QIFQb/+3KlGvhxD6pkg20NKuTJo3hgBB0VLW9wPkXdmEQHJLM5Sspq3RGvjE37LAdriceHA\nfsEztO9X4F+dDZ6KxZe41f5zx4MUsHhNWNJ4p78olvEV6WGWABbvipaZXjwQALBmzAXqryC3k8gG\n8+qitMfSx1LPIhIUkHa5f1f5G7yPvDASRC+Z7rkP0v4FpIog18Yel8t9zCdLOUv/RCQACDLMp9N9\nbPrg9yPPkMdlY+hLDqyL85gfNN5DNvHQsQT4nZljQMhgz8+S4PbQ5yQof1r5DWtS5dpvnSc46nPt\nfwv8u5f2eGxRvbgiAlItOL/qR++gPo57L7ff6txGsh/eSewpKRm3U9iWbEN/4oQjoud4B4BfttZ+\nyxhjyf4UQO7vGogTl4iIiIiIiIiIiIg2cHIAVLGTfaKKGWPOA/D/AlgJ4O8AfMBa+2c1qvgxAHsV\n+5kArGJviXk9cbntttuwZMkSbN68GZs3bx50d+Y0uq3/3qq+MjpQv+gFxjRzHgC3ElYt6H+QiHSq\niIiIdlEmfhLK5MfhqjSlsnG7HUptz98DaBXXWHZu9fdFXRpgViihuFz/xQUmJycxOTmJw4cP973t\niBROAPi31tonjDHnAnjcGPMX1tpjFc9/DMDPwsW5AGGy8h4A32ynQ/N64nLPPfdg48aNg+5GxNAj\n71pvPZB79z3lTil6qRSr6FTt383lL8Upv+X8LCUvcHXSMt1U2mAKSiPdFoDkhbuOrk/yvTDd5HZ/\nnAPhNcqXUOfupPoe9eWElpaigCn9lHo5UFryYtxI9b6z5FwOjBVqHCWjToZiFh1gmpDAZ15f+Qsh\n0H3vc44KdexI+CM0lrn2JDAdCLSohamMJg5MxZKcKJy7RGhc30bINK9Rz4RmJjQyINCtOO/JGuVc\nsXGm+3EfsM9ULckRw+fOePbAOuzM2URkgKllko+GaWFyjUx9e+Gou7cXjweK3PdBwfYeixa7H8nS\njeE+JkH5h+hHObnQbUlcAUf8lvOpyDOpiTVcSjahimk0xv0N6mDNj2xN8asViCImWdTzmd6pbqae\nKXS1Xk0MWtU7CHpZKyGYAI2CXFEoJkXh08bjYoGXVhiWeyoLytu3b8emTZv60ma7OIkFKWGTfrXZ\nD1hr98CPTtbal4wx+wAsA/A3Fat4H4CHjDHr4eYc/9bvXw3gp9vp07yeuERECLqxmtdZ251lTK7a\nr1bljLmrRCJ5eCU9IyIieoNuBvMXjSF1x5Z2xutef3C38l4Mw/iZ9+B09t6JmF8wxmwCcJq1tuqk\nBdbaR40xVwD4j3AJJ98KYDuAN1hrYwLKiOFFt18aLVeFkpjg3r2sqk9wpFxdipiy2g+Q16RZUi9L\nGisvTHVF1ZdTpTZbBIOKDOsEn7MV9sHMvdCGKQk21nLZpLwb/rgWvCz3h1d7C+SfAQD3IV9uD9mk\nLfakSKA+X8NDymqnrD6zV0dW4Fne9ohbvV9+YXA1HVrqvBvnLwteGJECZs+HeBI4wP5Z7z3glTiR\n+WWPhhx/PWWmf8x3VvPqLMAJ6suxXLv7sRwAsJY8JAIWBRBviSYK0MQF1GfnRWKJZOmXBPjz9cg+\nSy+v8IH9Z5EcMosbCEQ8YP/R4ME5a9yd88rR4K3Bw+5vtfhXQ5D+kXP8OUx2EO8LizrIc3CIbPJc\nPUU29tII5Fm6r5XYhjIGiCfz3kawTSB/Lglq2AfdNuR74jaUTO7Sv2my1fAI1ctxUiQZnK8T6I2M\ncX1UHfO1CUTJudPaPUuXz1Ptmuo53fDCzHecwgKc7PPn9KkKHhdjzBsB/AcAmwCsBvAOa+3nMmVu\nheMErALwVwD+tbX2fyt1LYN7yP5Z3b5aa3cC+L/qnleE0RCCjoiIiIiIiIiIiIioijMB7ADwr6AE\nwhtjfhnA78Gtrl4JN3F5xBizIlNuDMCfA/hta+23s/Uo9Z7N+2X/2rmo6HGJGCpkV4WyLvd2KQK9\nzF1QiX7Vk/a64+bvKAeMrMxqMscREREjhWScLIiFSSW4nGeoE9jfy7xa1evJ9iHSwuYbrLUPw+dO\nMUaNmr0NwB9baz/uy9wCF0j/bgC/S+W2AfiytfZPKzZ90Biz2lq7F87XrKmHGW+vHawTJy4RESiY\nBNUNglXq1F9gWhBlK7pXUyknbv7yfAnGaPkeSl6s/NEi1KpUMGgzX27GUdjM27QKFRqVlgMmE9Rr\nbQPmt6kNyfic+aiyR1tM5iZof5W/DqbeSPtM1bnOb+8lmwRXX0ft7/f1MS1MaKT5UJIAACAASURB\nVECco0NECW6i8fsB9x5hipOAKU6BshXoURKA/zxRrNYqCTkkt8urKRqVo6YJ7QoI9C0OcA+2lYlt\nnW9DAuK5X0xlk/0LqJxcB1PZhN7G/ROKGFPZ5By57q/hjckxoahxvU8QzUwgdLDx8ZBbZu8uf73H\nQ/vjF7rjC04PFDn8pNscadJCJP/NBVpOoim/3aPYmMYpFLAplCNFEfPQxip5dnlRQTs36QsdK6OX\nbtia0EsDtDEobQf0cbZ6HpeGr79S8RGgheWpXelJi0LNy5QH6H7zM6DmANvm26jYzYjK6LUc8lcn\n9+Crk2mq648OnygoXQ3GmL8HRyH7bbFZa60x5ksgyRFjzDUAfgnAE8aYn4ebbPyKtfYpFOMfAjjg\n99/UUUcVxIlLRN/R7YDJqpKOrfoS6qjWp9aelmatvrSDbgT2dwvG3BU+vrpR3+UAbqrSbrNrbUZE\nRLRGzjPTIllu+QKO9gHfv0D2bkv1t92PmhL0ozbuDct9HkX89OZV+OnNq1K2me0v472bcqEodbAC\nztuRDf57CQhyi9bar6PmXMFa+1UAMMacDqcc9jFrrRbF1xbixCViqNBq4tHuYKdnH26BY9rKYcnL\nll88yeolSxU3UQZNBjM5N6l7awtJ45uVe6hIbV7ur2c6/zJJ1+uvV/OGaO3nVnQbqfaT7NuafOoW\nsklwcyoQX5FXTs7VPClKgL0cv53qkJXpCSon8fL8DNxxc76fyzP95f3ryKaszi9+rwv0HvMB9ACw\nadnjANIyx8/PuvZOjoUVPfGuTNNi1hXY4crRyp8E9h+jrPKHvIeEvToi5fkmfCWxSeD6FfhuYpN6\n2EMiQancrpzL2exFQlkLYuX+ybU9S1LFDTyfup5NdMP3ei8Ry0CLeMG+2eWJbfm4u99rsDuc23yN\n2zkj9EXuy94nSav4uN+uIvnpu70ccmgCiaPnbrLJ356ljxPQcyjP6QQdnpJ6qZx4ddTxiSDHp+l3\nP97wx5pUzkmdm8sb1IZS30woX47eL6QMWua47LhGd07blPG4ZNKiU9G4vrz0fplsf5wwdB8uOL+/\ncshVgvMHDWvtCWPMfwDw8W7WG4PzIyIiIiIiIiIiIuYP9gE4CRA/2OFcpImtneJ/oc18LUWIHpeI\noUe/Xcza6lergPiy/CeV21Xa0PjLVWgURSt4yUodezzaQFVawzDkLoiImO9Q4yCyxzU58gGgd7my\nHHr1/ui2aEq+Xka3hVnS9dWlXEeMHqy1f2eMeRzAmwF8DkgC+N8M4L91samHAPyOMWYDgMcB/CjT\nj8+pZ5UgTlwi+o7u53RptN1GTuueP8gXbc0EfoMCwxXKViHPO5/HJVAEtirnKkGex+4qpnG1QnId\nzWBLqF95alk683P5B08eLUQG5Ph0i76r4gE3549JTM1jmTJACIi/rxls2seZ0Ho4mF7Wm7Tr5mBn\noc/cTrap/Ck4wwflHw88RQn03r8+BItLTpTzEfK4XDnmKGCvYmFik4zvQskCQu4SplhJsD3XJ9ns\nmVp1uqePsQCAUKbOStLBBwrWIZxDtsW5NgQnfd4Xd85SbwsUh+Wek7eSaNZC/VqOkDNFrncl9voy\nQTAg9CmIA6zGLgDA2Fig4e2aXQ0AOGcsXPfaq1186c7tgce18zmfe4boY06XB8Cvkk2egwmyTfkt\n0wQf8VuO1xK293lk0/ITCWYof1MyRiniHZSTBQ8p9Ug5TYBDyXjfMlmh0MyM8hsHIGNfOY1KaRb9\nozR1v53sGLg1M8aW0PoqT0hYfKWeGMKgMEx96TZO4rSEbtvPNlvBGHMm3Eglv7ILjTE/AeCAtfYF\nAL8P4H4/gfkOnMrYOID7u9jVD/vtv1OORVWxiIgsOl1pK4tL6Ujysg1Z0arBmHW9Pznp6HkseRoR\nMayoG7zdL1QRCOnEG9EPb0kvURRnUslzXlJGOxZjWiIyuArAV+AmCBYuZwvgZtfvttZ+yuds+U04\nitgOANdZa/+2Wx2w1nY9JCVOXCKGHv0ceG1YwNYnCqoscdVcMUpguuqlCS/3XGC/KnmprHZ6D00a\n2uppCwnPsizdmkRyq/rknPPSZvtgdjKn3CsA9omMvLP0S8ptofL3ZY4BwUPC7UsgPgdPi9DjBNmu\n9dulyIM9Lu/12+CowGsvfBZZHJp1FbGnQrwG7PmQ49/G63M28TYAQRqZPSlSjwS3A8A6Lx+8NJXK\n3YE9H+KF4QD7i/F9AGmPh3hmuC8SgM/lxGO0n6LZRXL5eTRyfWGvjsgvi4SzCBYAwPiY8+qMk/fp\n++R1EhyectHvO/YEtYaL3uV0fVdu/GFi2/sZH7B/Sa4K4Prg9SqVQ2bvyYTfPko2OZdFHbSg9y2N\nfH0Fnt1aalyptrSxoGSCkRLWEI8s2Y6VTU5aZ2rvxXjfj3dId/K56OOn7l1JH29nIa243jjZqYOT\nWKCKjvS6zVbw6l6lEwdr7YcRvCJdhzHmXQA+aa19NWMfA3CT5JCpgxicHxERERERERERERHRbdwH\nYIliP8sfq43ocYmYN2jlWh9Gl3qvAj6HDVWDg827+9CZiIgRxKjk9Wid/8odL5YBLvdKtGqzG+X6\njar3LCJiCGHgaGpZnAfgcDsVxolLxJyG7gqvSJPSgumTjwMtqD39/0KUZa0vaF+HRqfSslo7pIPu\nm25HiYXh8/UXeck95fwod0sb1D+hlM2QTagvnPhdgowfojYkV4sWWHxVaNd+zPd9j1JH2eToXtqX\nwGsOqGaqDzLHr6Vx+YzZXLEf7HI0riUrDia2q8ZczhbOYC/Urlklk/z3vxG4dEuvdjQvpnsl+UeI\nnrUeT+fKSQ4Wbnedv/lMd1jhOXTLEy4d8ALOBxCC/rnuCzydCwgCAVxujQ+Yl2B+LseB9UKD41wx\n+zy9TK5R6GFsax5oJLbZQ462du2FX0psC97q7u0Y5cj5/tPunq5eH6h0ST4VTpcm1EJ+HoTuxc+t\nsOBuJdsjSrmbFJuAn+/7tIULyajeVE7W80YFmzL2LEr/rgGoeag0JOIiYJqtUl7aKKG5FfWvKLB/\nFFDlugCKX8rcnxwFbFH+fndjsjVMk7RRRMzjkocx5rsIsTVfNsacoMMLAFyAIHtSC3HiEjEwjHom\nXe3DYBiQXbGs82IrW9EM19tqQjVYJB8BE4PsRURE71BNNESRVe+kLVkg0SZbBX0apnFRkBMj6ZK3\nQhtni+ou8yp1sw/aO3bU37sRI4PP+u0VcMs3FPWJWQBNAJ9up+J5PXG57bbbsGTJEmzevBmbN28e\ndHciegh9cG41YGv0rG0lxzpD+ctuW8mLqKn0r1VbDaUt7ZoqXqd81LDXgleOE4h4QHoF2dmoLy+K\nd4X+RhKgnAkstrahKy7JinnGy+IC/LkORWxAVsQPUrH3Ig9Zid8RNF0XX/9Krtj4uFse1QLiGeJt\nmMHaxCaZ3l93dchgL6t74m0AgqflumSJH1jsj5/rZYSB4N3gYPYFiRwyL4o5vEQeHGlXuw4Ozhew\nKMC4l0ZmT4pIH7PUs7RxjEQB5NypAxOu3mXNXPkrlu1IbN857oQMOEj/0AF33bPPnJ3YFl/hJJd3\nf/yC0Gl5vbLstUhmswjDO/z2TuRxr2JjqM9ysCW/z9/2z+QdSjnQ7/ht3sDeRW0skN/TurQ566Ut\nkiguhHYdqePVFk/KjzX8Xv0P7VYTiap96ASlfWh1/5JymuhKVQbBaGFychKTk5M4fLgtNlFfcRKn\n9d3jUkUOeZCw1t4FAMa9bD9prT3erbrn9cTlnnvuwcaNGwfdjYiIiIiIiIiICA9ZUN6+fTs2bdo0\n6O5EtAlr7TYgURFbiYwomLX2h9p5ZZjXE5eI+YkyScm659Qr3yLXQYs8Daq4wNuUgmXlC7jUowxj\nmgXenaLyrfNOREQMEolH8IONPrWXHQ+68/uoEpfSirrUSwpapzSxOud3m5LWmvaridE0u9KHiDRO\nYsEAElAOd4yLwBjz4wA+BuDq7CHEBJQRo4Zh59aWBrRWyEdQdA4HtAIuyDI1aUkCWZupc3OQHCs3\nNGAfdLtJ3VqQZ8HEqEx4QOdt+48aniwQ7z0EjTaT/gVoeWEE9LE03SymgGn5JrSM4BoXX+7LFir3\nmJJbRihiG4Jp7KqXAQCznw9Uo+QcYu+eP+7oXlqGeA66//Jzbtb5jgs/mdiaPrBZcq0AwGOzbrXx\nyrFAhZIg+dfj24lNqFpM2Vrr69FoYWyTvnIeFwnUZ8qW4CgWJftHfHtjCKIETC8TCG2L89ZI8P5C\nCpiXelg8QK5p6bJDqf5y+e9846cSm1DAjh4NfZ/d4/5uY5e8HPr+8Aq3w4H4gi/S/vvlBLJpdELR\nMZgg25TftsjZpOKOsmD6gOT3fznnVlIC+4mGJiinpjapvmZyLNW23QotID/9kVwe5N8vpAVKeq8g\nVp2ilheC0f5f9Leq1oemtwzH3yJi3uB+ACcA3AhgN3SFsVqIE5eIoUIngYNlL6J2VrvqSFB2EuRZ\n12Og1lHFW6N88ADZxI9UPmdrVutLlySLy/ocERGhBM7XOadr5fK/U07kmyqH7qiEtTvpaKfNQUsk\nFwf4NyueX1yuSHBl2BcVI0YKVwDYZK19plsVxolLxPyDIilZjvSqqJMirThJ0VZHqc3kxaGtxvK5\nE+KpoHKyr340KKt0WhsckL6h4QPXW68M5+RYZeLFcrHkaUlWhDUPTkJfo/qSIH6lDe6zeFXk2jjo\nX8prWcI5Y/n7/fajyCMo92L2gbNzNlmpX/yL+0I571XZuf3SxCaZ2TmofeJCF0T/2S+Em/bat7qx\n/SDJA79+7DsA0l6GN8PJ/HJw/movN8zeGvF8cDnZ5/pEqngfViQ2yXDPHhw5R4LlgeBxaSqr7vsS\nfWDgSjiPkXiLuF324IhE8vd3hcD6TWvcH+zZo8521ni4HvEcLblqT2I7/KLz5IwtJaGEpc6rMztF\nHjOPJbfTuQ94PeQJKiCHOYO9eGmuIttjik3Az6146jTP4+2NsP8IjVU+gD5ZGLhPOXeabJr0Nx9P\noAhcyG9mSyNV0n4sLYFcRjnlVf3y8bLcA1DNQ9QOOvc8VP3Ab+U1qT9RaE3lywu3DKfK21yAk0Pu\n7+f0sMshE54G6MXSBQy3LEFERERERERERERExCjiNwD8rjFmwhiz3BhzNv9rp8LocYmYk6ieKbmZ\nsfRWUrJX+v35NtoLrq26mlkmClC5LYWiFhER0X90m5bZj3GuG2i3n3XpY0V0rVa5sXqZ58Wh3nsi\n5oDREeWQSyFZgL+cscfg/Ii5gU4GwjJ3vJo1vhU25GkaWn2l7bdU7yrJC8PnPnRzUi6XGZvzPpRm\nxlbqTlFHtL5sy2wRRAHYJhSt+7jdRnFfOI/EOsmtki+e7rPv6zS1K3+jad9+imbjtzNkk3Y5cF+Y\nt3eTTfY5GPsn/ZbV6P3xBafn858suSzQjyRInClOT2M9AGDtW59KbBJovhyBeia5VYRWBQAX4/sA\n0sH+K32uFg66X4+nAaQD7KUNpoBxhnuBUMo4SF761UTIe7ILq1N9cscbuTbExjS4071QwDlEodvt\n27tozbOJTT4KRPhg54GQ52bnHk/JY/rftS7+M6H3AcD1Skyop/0dvntVsB3MF0toYTeS7dam217V\nCDahgHFfJvyWmkgoZ/wbkef7bvoNa7/dx/ImXCfbBuyH3G4yPrSMn9PyvTScaEh2PPnY1gzV1e+0\nEhJRxrfB0JbqL0z17uO8ncWlcE42r00r9bVykZk4AYnoGd7U7QrjxCViaFHda9J7ad+qgfhVX3Kd\nZbJW1IKGHK0+oqJMZ0TE8KN9Wfj8WDXooPdeoZtxJWX3u4owQz/ejRERZbDWfrXbdcaJS8S8Q+Kd\nSAWjKgP8dPuDfpEMZvGkp5wqoOdf4XO2ZtpthkNq1ur8h0LweOQVZlL1PSQeHq0O6l8Sv52XY1UD\ngRmqJLRSX+I58X2+m+6BZC9nT4qserMn5Ra/ZTnkCbdZ/a6Q+X33F5yX4a1v/Vxi+8JzPwcAOLzv\nnMQ2vuZYzvYP1jjZ4h0Hrkhsq5c5D8paCqaXIPUVia5u8JqIjDEQPBksLbzUuwpYAOCo97TwuSI9\nLJ4cAHgBr0ER2IMjme7ZJt4c9szMeNfWxQhek0Pe07Kf4jS/s8tluH/Dmm8kNvH+7H46eHXesP4r\nAIAdu64EAIydEeSTJegeVy0Mth3+YWbPnthY20aeH/akiEgDSWEnTqLbybal4bYcJK8JQoiHUPOe\npDLYizhG+vfCx119ymTgbir3IV8u+R1Tu6onpbMFEC0IPI925OO7j271oW496clL2dirvTtaCKMI\nvLhKeT86u/5h+BsOI1xwfn+pYiMUnA9jzBsB/AsAFwL4JWvt3xhjfgXA89baR+vWNzIkuYiIiIiI\niIiIiIiI0YAx5p1wxO1jADYCkBWmJQDe106d0eMSMZIYpAu83H1fPfdLN5HUWzHAtg5NoyzPSzdy\nMnQb3cojExHRb5TlY6osnNHn32KrHFKpsj0Y/7ojL9xb1KGPVXuH6F6yVuP6KNyrUcSpAQTnnxod\nv8OdAG6x1n7cGMMJE77uj9VGnLhEDC3qDKhZClaVc9NBpvmgx1YvkEpJLjmXQgH1rE5f0wHs0meN\nZrZNKdcKSn1J/6sGteZzI+TvS0GAL0Oht6n5XhKqje8n58+4VbZUXoL3N1O5T/gt52fxcfX8Mlp8\nrQtM/8L2t+e6u3JjyDi/+xuO4nTR1YG3IflUhB4GBIoV5zVZ57lLnHdluaeNcXZ5sWn5WQ5R8LsW\nYK/ZpO7nKRfLQh/ELyICALAS7jpnsZBsThTgFbqB61LqBw5CW2PhgdVrdvm+rM71b+n67ya2bz43\nAQBYvMpd95EmpQXQst5/3m8nyHaZ3+5BOd7rt5yz5T7/PPLvWYLkOcZA6IYvkm1Goz1uSx9LQRHC\n4PxNmsBFks+omS+HivmqcnTZrWnBEVrASHLKqJOWm4vpTF1A60zyg0V7MS36WF5ILeZnroTSPOz3\nKmJe4GIAf6nYDwP0sqqBOHGJGClUX3UsnsTwC7UrgZM3dLZi5frTWxnm0FYfhAzkA6fghVr3g6Yb\n0ssREfMZ7Qh65Fb26WO5umJZnbYAXTUrW6a76ERoRY9hbJJFV40070aYDCvHW/WtKtp5XwLF1x7l\nkHWcwAKc6LPHpd/tdYA9cMsszYz9WgDPtVNhnLhEjCyyg2Znq0sVA93V8h43bE0yxKv9SALOuxcY\nm8Oxu/zLk43bSpXQSjGt1af12d8PLVs309fUYHsJOFXuyw2N/Ln8sZTNBH4dHROVYa7jX3pJ3Afo\ngibcJpV5fcpF8S/iwPSmEsC+1NW3d1eQE7726i+6rs2G6O71Y98DADw9+7rE9rNj7mEReWIgeEEa\nNMaLDDIH2K/wXgvOdD/mvSbLKbBf5JJZAGAn1ubaFVEA9qRIED3fA/EOnU59EU+KeGNcG+t8HcsT\nmwgKsESy1P2D5y4O1+Gz3c8+Q1LGZ7jNkeP+etnLIkIL7DGTYPsG2b6FPMRrwl4Yr65MXQ/PMHv0\n5ByWOZb6WOhBJvAp76t/vlNS5s10WwDwkGJLZMG1j3vky7WSJ5bf0wS3q4wVmldHxjKFoqovCmlS\n651hND6e6Vq36F62rCxx6XjNDs1FW6t51EZIhTJiTuFPAPxXY8y74fK2rDHGvAFONue32qkwTlwi\nIiIiIiIiIiIiIrqN34ETAvsygHE42tirAO621v5hOxXGiUvE0KNo5akq5assO7JW96jnF6hNxWpB\nI6mUS6BDDFNwf0REPzGKeZmGDb2gMJXTjXsgMlBD5CB3bovkkxG9hZND7u/n9KjIIVtrLYAPGmM+\nBEcZWwzgaWvtkfIzixEnLhEjh2p5A8pQl6JQnmOlHJyToexld3OeMtKyn9uKaVyqulgrmkawleYS\nEK57lqYF6HEtGjVOyxiu0VeYhiP9Y0rLlC8nWiWcz0IC8X+eqvg1ky4PJJSfww9QY35I/cF5lyCH\nVZRD5JBQq0IGe6GIrRnbndgk78m5Y3sTm3CUV1LeFQlM5/wn2ToAYJFPksO2Qzgnd45QzziIXyCU\nMSDQvcZIAGChv6Ym8a2EhsaCAkJb+zLektgkYP8gxV4KvYypZwuJrpbDDtr/ycwxpoVpVDGhbL2f\nbLLPtDCmdAkkfczzyjE1Zws930QDsh9z2+T3mdIrKPlta0H8x1ikolF8LiPpX4t2j/nf3UNsVILF\npZ7U2FJPAKB1PpO7Co/3ahGp6oJW1fO1a0xNSiS2pZUCpKeAtc4FVjzhTdOnmwV9rH5vR3EhL2I4\nYK2dBXxSsg4RJy4RcwatJjPdXiXTJhidDOzDtPIaFWgiIjpD18cbRaRi1DyVdTwjRR6PKnUUedk7\n8cy0J3WvLNTUgM4IaLZVV1G9cTLSOU4OQA755OjIIXcdceISMfTQBtbWbvC0Ok2rF1b9j4xqk4t6\nK4yC8kDN8hdNUSD+VqirramA4WZSR4Cy8jotq35kU4UHfLmWFIht6TpS9ZBN+nppMGHKbyf89sZG\nOPbNTBkAeI/SvJziA+0BChA/HoLVL1rjvCAcJP+9Qy6TOw6R28uv4u88EDwa48vccvR6WnASDwR7\nTS5Cvg05zjYJemebvDhZ5vgc780RjwoAvOoD8Fk2WQL1Oau91CfiAADwhE8nz8H5Uh8LCkgfzscL\nie37CAH4gt0HXLm1F4b7svMb/g/8GBUU7wdnsxeIbPF7yfYBv50gmzwPT5Ftym8/othYDlnqSckc\nyw6NBXKO5l1l+eLzROa4mSqijVUA0sqFx8oXOPKe29ZjlbWN9MRoSna2khS7bzcludxoWXcd5D29\n9c5r59xW9XVSJkFKhEH5e2jy75UXsrbVnHz0R8EyIqJXmL9TtoiIiIiIiIiIiIiIkUH0uET0Be24\n6Lvlzm4VgF/33PLyTb+n6/enj3XWbhXRgl6hVhbvLq/KRkTMVQyKomnMXYX5qKoGjVfNnVV2nnZu\nUbmqx6ocbxd16q3qQWln/Ja/UTbOqEosTJl4TUQ1uOD8/lLFhjk43xizHcCbrbUHjTH/CU5BrJJo\ndxW0NXExxpxmrT2l2QGcZ639Ycc9i4ioCaZllU8gyiYOrcsViwO0E5uiZ0wuare8jjo23x4H0ydU\nLaKHJNnqW3ROaDDTSntargqGfDBxbg6h0jBdRwLqmeojeCBThsvdSTahEP1RoIVhxtG8Vm8Mfdt/\nwCfxOB6C7psHGgCA2WY+v8jiS0I2+AvGXD3nLws0KaFiMe1KaGMcOC85Tsbphmu5XV7CublzhTa2\njnK2SBA9v1Qlwz3ne5nxgfp7EfLRSH0LcCKxCZUsXd9ZuWsTKpvkhwGAvc/5gP5HiVbn/+Y7ryL+\nn7DVmNY3hRTGbnw52Z9d5/8eH6ACE37L4g5yuVNKubuRB9O9poQK2Qy2JCFjAzlMa781OnfGn7Oo\nkadiQaELZShlqXpzkDxUro3UxKMst8tDd+UnHNqkJbMQoQWQd4pWH9GdHG/3A70qfSx9LxTqLt2/\n8LfXx+tC6iCjVZB/Qb2u3RjLGNETvA7AmQAOwg1IHwEwmImLMeZsAB8F8HPGmJcB/DGAu6y1Qnj+\nMTg28sCmgsaYRQC+B+BT1tpfH1Q/IvqH+RJoaMxdbbyk6NzaWbPRdnu5+i7vSjUREfMCnXxQ5hZt\n2vgNh2SYjQ76UU35qlco8lx0431R7O2u593vRIq+G+XbqXcuv2PbxUmc1vdM9kMenL8DwH3GmEcB\nGAC3G2NU+WNr7W/Wrbyux+W3APwEgF8BsBRuLXOjMeYXvNQZfCcHiTsQwjAjhgTtDHadDJBhRUks\nLQLTAdgnsi87WfFqIg8tgJ29PtUD8bN1pOspO7c4ODe9ylr+Mguru81Mn1AYCFzWv1x9G6jshoa7\nz9y/Kb9lb4nIzvKHk2Qyn8hdQlidf4ZsH/XSvneGAPtkVX4PDVOXuXK7n74gMa1d79w1LPs7doYb\n4ljA97XrXYPsIRFPBXtDlvogebaNKVLAYpsleWUBZ6FfioO+XLg28YKwfPHzfv8YBec/64Pkl2Mf\nneteBZzVXjxCMySb3PBR8hxoL/fo2aPBtnzc1f2D5yggf4e752vfFVxmO5/2npbj2avNQHQEvEdv\ndhV5vR7IlQ7eu1XKsXVKOZYq1uS5Bfwsw48Z7yaD1hdt4pD6TW5Nl9N+r6kJRD5Teim9aIL/04B9\nkMdFh8KxNiXNXIzWY3V3lBfbb7+i96LL/VEnJt4DXf4+aKeN8nJ1j0VEdIBfBXAXgBsBWAA3AOS6\nD7AAej5xeQeAm621UwBgjPksgL8A8D+NMW+njgwExph1AC4G8D8BXDaofkRERERERERERETMN1hr\nn4VfijTGnIKLd9lbflZ11J24/BiAH1Dn9hlj3gLgEQAPQhcb7SfuBnA7gGsG3I+IAWHQgYb51a/2\nKRLDzD/uRACgkwzRERHDBDOOtKewnTrapGW2+ztS6Uzj0BPFVq6vDRoqqgfiD4NnoL1A/ILjQzIG\nliWljKiOk1iQeK372eYowFrbdU5b3Tv9Q7igG1HVh7X2FWPMWwF8AcCft9MJY8wbAfwHAJsArAbw\nDmvt5zJlboWblKwC8FcA/rW19n/T8bcDeNZaO2OMuQaDp6xF9AllLnP9mH/J5jK/NwpayLrvsy/R\notwpWdxc+HLQ864QSvKkaGAqiU6Xa0/trBjKtQm9he+z2FI5LfyW83YIJmhfmFzMlOWA/mz5Jz2N\n6k5yAj9s8u0LpsLuzmc8heknQyb52c87etLiXwwUK6FqcQb4lXgJQDqHiQahgzEtTKhknGNFuNML\niO4lxzmPi+Rq4ReaUNiY8iZ5YTgQX6hsTB/7Nl4PIE0fO9dfGwf2Sx/2PvqaxHZkhY+wp9w4ktk+\noYcBISj+qmBK/jaLyZalfO1BHvwsyDN3XiNfx3nI27j9BxrpfnjkKI6CAkO2KAAAIABJREFU+7Tf\nPVODKk5MEoGLqkIiBAryD/Bjn0obpTbUOBaNwpr/jdfNMF82RrdGvUWgXn+IVxvzPZhiOKMVKKbS\n1ZnE9WqCNwwTx4jRhTFmLVymrdd509MA/qu1dmfxWcWoO3H5AoAtcN6VBNbaI8aY6wB8sZ1OwKkP\n7ADwPwB8JnvQGPPLAH4PwD8H8B0AtwF4xBhzkbVW3rQ/CeAmY8wvATgLwOnGmMPW2g9k64voLbKr\n8d18gRS9KDpPKFl/5bCXqCU3DI7p6W5QfR1IAjv7YHm5iIhRxLCskgO6zHjW29yLsaAXUuu9ksrv\nxGszjB4fQR1WwTBfx1xClEMuhp8bfA7uG//r3nwNgKeMMT9nra09b6g7cdkKUFpmgve8/AyAjXU7\nYa19GMDDAGBMNmwQgJuo/LG19uO+zC0AfhbAuwH8rq/jfQDe54/fDODSOGmZXyjPnpwPLk+/hLcl\n2+zgrg/2rSY4/ni3cpgcu8uv8NXpg8eirYpkaVm2ZW3FN73ym5OEvqGRr0ZWkGcaeRuvek/5LQcC\nf9Cfc1Cp73ay3eK3z2S2DA7ElxV29tp8y3tmJsjm6xk7gzwui105CTwHgkfjjfjLxPY01gNIeypW\ne6lgzjgveJU8Li/4czlwX2SGd1KQ/BXYkatHvDB87g5cASDIJ3O5dbT0K4H/3GcBSxrLcQ7EHx93\nS/1jV5FE8ZQPnr+E7v067315mG1++3wweecPyOkUjp/jt/wMiNeGA+O3NPI2wQTtayIQ4pVgaW/t\n418oYnsy48WDBR5e9pZq9akr8ZqXw/c5FThf4pnRAuy164UirJEqp9RTIOfu6slfY9UPZ61cNyR8\nOxN8qXY92mRBW8yrPpa38sC1v9gW6WERfcDvALjHWvsf2WiM+R0A/wVtODxqTVystQeR/pTgTiy1\n1h4C8NW6nSiDMebvwVHIfpv6YY0xXwLwhk7qvu2227BkyZKUbfPmzdi8eXMn1UZERERERERERNTA\n5OQkJicnU7bDhw8PqDfVcQqnDcDjMtRyyIzXAfjHiv1jcPSx2mg3AeVvAGhaaz/p//8pAO80xuwB\n8DZr7V+1U28BVsDlhXkpY38JIE1OgrW2EjH4nnvuwcaNtR1EEX3CoLTjQ9JFZSWygC5SlUJRSOeo\ndG5xG+1kju4VNU6VQY6ImCfoNqWsLj2rF3SuushSWIO9KgVW8U61kHVvt0/dQrfve6scL53UOayU\nMW3hePv27di0adOAejR8eGrySTw9+SSOH361deHhwN8CuALAX2fsVwBoS2msXRmEWwD8EwDw9LCf\ngdNp/scAPgTgrW3WGzEH0C/3c50gxZbB74LKfHAt0F3JSHysfb19PYFbxQDZgpd8eV+0uov7m6KR\naJm9JUBaC0zNCSMgTTfTaDNCD+Is50L5EirRz9Mxn9UevID3Lz1daUe4sLEJR3GaPUQ0KU8vW74s\nBKG/cr2jYHFOlHM8r4mD8yX/CVO2pNwuYtrKcS0LPQf2T2NDql4gULu4DQnAX5pwrXTq18V4FkCa\noiaB/UwpkyB+vrbpA64vfK+OzPhAfKGCASF4nql7d3hBynsbwXZVpjwQKFr8DAil7NHM/4E0zUwg\nFLEJ5Rg/q0JJBGDf57ZqFvMkcJ7OlSB+plCVUkNLaF98LgXaV/8Y1nJO5fNLJb/nFiIf1WlZN2e2\n/UHVLPaCupOKzj7s839n7Z1YTG3WxV9cuXxrke41v3Dp5stw6ebLsGf7bnxs00cH3Z0q+BMA/90Y\ncyGAb3jbNQB+A8Dvt1NhuxOXVUDyZr0RLkv9F4wbHb7dZp1F2AfgJEBvVIdzoWvLRIwIuh04WDVw\nv9/QVmC1F2k/siR3S2JZCw6OiBhlmMv70MYQeEM05LyvXfaWdlvavcwbX9VT38n7olUbVdTTOn0W\nAjNA6mmlGhnRK5wcAFXs5OhQxX4LwCsA/j2A/+xtuwC8H8B/a6fCdicuBwGcDzd5uR7And5ugO7+\n9ay1f2eMeRzAm+GUCSSA/81o86IjRgNVgyHbrUsPKA1QV7cSydHy1TyVWpYEyefLF0H3kJTdAz1Y\nthhlQfot5KQZ4i2ZIpt4Rj5PNlmx/nQj2Pi4QKSRryObrMBzwLWshEsy9nPo2ITf3ku227z34Jsh\n4/zsOw/4OkI29sW/6gLwxxDc8eePO08Gv6Am/AWzjLBklX89vkO2iwAAi3wwPwDsxUpkIVLK3MYb\n8TUAIegfCBLK+7znhcHSx7wvkLrFkwMEAYAXjobyIkLwg+2XhJNXufsxtvQV6ou/b4/SDyY4fQLE\n06IF1l9BNvGiPUU2uUwRV2BmtDwX7PmQD2/2rsgzekMjUb4rnazwx7uISbC88pRyTtKH6h+O5Svm\n/nfMnuCybPYFQfcyZlT9yE6wYSvsE5nymYWYvPBHNW945clMIkxSd2zjNhu1z6mP7srJl73/qtMR\niyX4IyL6AWutBXAPgHuMMWd52yvlZ5Wj3YnLZwD8qTHmr+FeKQ95+5Uo0EYpgzHmTLhPEHnzXWiM\n+QkAB6y1L8C5k+73ExiRQx4HcH+b/QcQgvNjQH5ERERERERExHBAAvVHITj/JBYk+bb62eaoodMJ\ni6DdicttcMzi1wD4dWutrJGtRnp9syquAvAVANb/+z1v3wbg3dbaTxljVgD4TTiK2A4A11lr/7bN\n/gOIwfmjglareVVW7rpFSyuKDcmXa7odNddC9dXY4qD67iF4gGqu7kZEjCjMuwfdg4As7ajbv+90\nW01qq1HxnEyQeEH+GM3WLZruMOXYyqJuzi09uWfvA+c10RnGoCnVWciCcgzOj8ii3YnL7QD2WGt/\nL2M/DODH6lZmrf0qUE7Ys9Z+GMCH69YdMbzoxUDZ3Tqr5klpFB871lQCXZmeVZO6kUFV3nSunFBk\ntCB5DTyZ0bLOCyWH6TW3+uvYQOdu8cc5j4pWrwRtc+D1R/yWqWKyL+dy7g+JgPss2e73FLENZHvE\n9WnJuhAyt3TMcZ0OzYYK14+54HjOON+EO3chUcokiH6KIsMl0/xB6uBJP/w26CJ3++B9DsT/U/yf\nAAKNzLXnKG/7sYLqcytwElQPAGfBLXA9djSkhj9r3Nn2PhdoYXuFUnY80L2OHPJ1sw+96e7f7CWB\naoc/8NsbqZwmmi+XfhPZ5G+qBeJzNnuhjclztqcRjgl9bAvZ5NzHyCYZ7rfQ80j5hBL6mPEflpzB\nnihioZzyfNPvKfndv01po8VHZA6eLuXaFWOWmrSVqKwthDVUUH3JtSv0J3VMK0d3aL+hL4PIHl8H\n1cZlDrqvN1lN/52r3ZeIiLmCdicu/wLALyv2p+A+Jf5L2z2KiOgAna5a9SMzdLtlIiIiBo/q0ue+\nHKnlFXliq9RdRR63zvjVjzGnipKilpyxTr3dCKbvNrr5HqnDFhhUCoH5jlNYkCxE9bPN+YpOVMU0\n/eW/haOLRUR0Dd0YgPU6WntU8i9R5Rw1CNad1zKovbDd9l7oVVcl1ZXhy335aS2HAvVF5GpZvpiD\nlgVXKe3LajpLGssKPHtSJCj/XqXci2STfs349j9Cx27x28fINuG3l5HtW75rb92ZmES2+PVjIcC+\niQsApD0k4tFg2eEZf5Hs+ZBA/JU0bIqX5nScTGwb/M2dwdrEtslfwBTelNjWehfFIfLgSJ+lTwDw\nkm9XAu2B4EVafWEzsb1y1PV/9niQSE6C7hcjQOSN2WN2rd9y0L3cc/47i7I0e9bEycUiDBco9clv\n7Hb/THHgvtTBz4UE8/PfXpM6f0gRvRAPCnuBNLlvqS/ltVRoQNq5ZdnqM8jTx9oPAi/ylFRR5tIE\nQtpR7arWz8480e220Y1zi/+ODb/XPdGZWlCfubhgFtE7+ATyDwO4xVqbzePSNtqduLwAp8OcVdC/\nBvDyNCOAGJwfERERERERETFcGK3g/CiHrMGrAnddaL7dicufAPgDP5v6X972ZgC/ixBYP/SIwfmj\ngU7zlRSvJmaDI5u126nTbrfq1lbLKq1QFiTX7Ef+ioiIYUcSd6LFcPWy3RYUsHrZ5su9ut3L41Qv\nmW47dbfyRHWKbozV3c5FVlZ32j6cQgXdRAzOnzP4BIB/BuA/dqvCdicuH4Jzxn8YSNIvHwfwX6y1\n/7nwrIiIHiFPrapCp9imvhwr5VUAv6TK3O70gqmdsLGTvAAt4LNzpyYtWqB+kkOB+iJUGqbmCK1H\nC5zX6FtMrzvP18dB23Iu24QSxP0UMQBpfzocSvzBGlWMqsD1FgAwMxvoWRvGXEVHsSixvd7n1mV6\nllDE1pCjWShbnMH+a3gjAGAx0bj2ez6TlAeARZ5edgwhUcMsXCD8WuIuHfHtMqVMAvaZtiY0NJbq\nPPyiExc4PEPR2xLjv9QGm9w3porJpfPfXtK83Eo2oZTxJEDO5bw9Nyo2oZRxffu3po9pOK/kGBCe\nueX0calN5md8bhIKqk8E/wvzpJQjP6ZoY0bZ7z39oWpto2C8Kc+ynq6jXoB7fXpRvs96W8FeXnf7\nOUn6G+9R9HfsnJrW6v60W29ERA9xOoB3G2PeAuBxAD/ig9baf9dOhbXhE8r8hjHmtwC8DsAxAH9t\nrX21/MyIiN6g1SpUnZXGnDxpi2RfnaxiFq6qVU4w5su34TUx46i0uly3LxERow5j7gJu6PLqOdc3\n1bWq820pv1fNa1Huyej+okmRcEovxk9NVrof3pBq54T3VHVJ6mbt9tpFDPCvDxec31+q2AgF518G\nYLvfvyhzzKINdCSD4PO3/O9O6oiIaIXqgZrVVxtzkJXUGquoGvJ9pQ+AYxUzSsuHx6Igb6p9jCTl\nU5OWMhlTJeh+Wnu5hz6W9oW9ITc3fblGsE347S1UTs7hVW8JtGZvzXmKTfrPq+TihJA2eCImAd8c\n5O0xNvFysj97yHkoFo7Nhqa8x2MBBc4/i4sB6HLD38WViW0BTgAIXhYAaHgXD3trLvC2572kMhAC\n8Tnjvew3k6j10O7uA8Fbs3yZc0fs3hVseNLLFrPXxAfWL5kI8s+HZ7ym8K/RD+dOvw3FQE6kADnO\nAfPSVZZFln321nxesQnYU3ZV5phWnj0ujyjH5bfBx0TcQfOkpILq/e/pGC2OiOdRDc6vKnXLiy1a\nfo9tma0gO474c1Sv7s2pfeetaSrlqqMKXbW6J0WvW6unm+jWR3m+vzR+dkGgIP23ynudWB572GWi\nI+YfrLVval2qHvqr3xYRERERERERERExR3ASp6XouP1qc5RgjFkHYC2Av7TWHjPGGM/eqo15PXGJ\nqmKjgU4DSjtZXTSm2WHOBd1edfUrqWeRvorXGwEAPS5nmLKNR0TMZ/STOlQV9UQEHPohezxKyHrW\nOdFkUqZN2nOq3pp0vUHQx0ZJVSyiGMaY5QA+BeBNcNSwHwfwHID/YYw5aK3993XrnNcTl6gqNtoo\no2Lk3ezBxa4O0se0ct6WoY9pOVbahRoEK5Qs7mcSJK9c6xNhPwTRtwjU9NmvzTi1r9HktCzmEjT9\nFPJg+tiE32q0HsZU6FOC6xpKOckpQ/2ULOhCK9LoQhzQ/R63mZ06OzGt/IUfAgh0LiDQszjoXjjM\n+5MkIels9oLdPth+AykFCM1sPZ5ObJLvhet7ED8LIB1gL9Q05lBLQP/snnAdyWUeoqz2EnR/PNdN\nHH5gVfjPlN/elC+Hb9K+/M2vJZuIIFB1CaXsDWSTgH3OjyLPFdcnuKMZ9uV5EAoaUwKlPqa0Tecn\n/Nji62D6YUIRpbYSCphORw1taLEKyked9CGTz8XaBszlDbJshX0iS/30tpb5oLYp41JZMHuaepYf\nW+rHYbSLTqlVReNxLz+wq9bd/T7osUdzkQY2SqpiJ3F63xNQ9ru9DnAPgL8D8BoA3yP7JwH8PoA4\ncYmY3yiTFk2pBLVZRzjeDelSUILH1oGk9QNsIyIi+oGsKmEVQQtj7gqTpLJyHYpjpMakAsGBKuNI\nLzwh0m6vJ0d624ORQ67qBanfl2amvkbbfYmI6CLeCuA6a+2LJh18/NcAXttOhXHiEjH0aDWgtwqC\ntbZRedJSXU2HAyH19ouUbaq+LNIrkU23wyvIvErcoq86tgaviPwfSK8Mz2S2QAjaniLbDQ23vY/O\nXe5tHLwsGe417w5f271+y9eY0NZo0iieFmnj7kY49g6/JXGAtVc7l8FLR89NbK/OOkX3l8ZW5ro0\nhhCwvwurAYTM8wCwfMz5Oc4lz4tIEL+E0Mb5eAFAOuhevDmc6V4klHeSzLH09fzxFxLbrKjQL1WE\nHM8g2vB9/kXxM3R8D/IQD8YU2cRhtIFsss9eNPFssQiDBvF0TJBN9rk+CeL/YCNfhwgtsFSydj3y\njLBnhjwtiVdTvBvs4RPXFUtrQ1/ZrxToXpaxPOfV2Zq2qbmXxLtS3mx1+HuVmUSxJ7cMZWNa3Qzz\nRWN563dAo7yTIwKNGpa+tnqTmzqToRjYH9EjnAlAebKxDEBbSsRx4hIRERERERERERHRBk7htAHI\nIY9McP7XALwLwP/j/2+NMacB+HUAX2mnwjhxiegaqmWrD8er2srqKSpXFa1oYZ1A62stKllBpvtu\nwZhm8JRERMwjdEtoQqONlv12W+eEananY11AVSGRsjGtemLf1nXVOW8UPQTZ+629T9X7U/M9EfNy\nRfQZvw7gy8aYq+AS1v8ugEvhPC7XtFNhnLhEzBmUurof5P9pLwGNfhEoVt1+EebraxGgKpnuWwXp\naoHFYruOyt3ddFum6Ehgu6aixtScmfzhhGK0hc6VNrT6mJYiNK8U9U0RGdDyuMi5G3wb11Ed27yN\ngsZ3fuNSAMDYJSGPy6LFLu8KU8CWjjnK1je3kwT9KufVXr0mBOxLXpYm5WKRlbeL8GxiW+g94mPk\nGd/ng/IlmJ+xbzYE7B952EXY77rxRGI7/KS/qGY4ZxY+KP+ZYIMXS1y98fnEtPsbPsL9o1ROmmNq\nlTwPd5Pt/bmuBhtTtoTCx/Xd77eTZJP8Mo8q9bJQwN2ZY+e0KP9iw21ZVCKbC4Zt95KNhDrKUZRj\nBYmYBgAYo+RYobxIAnXSkohyaO3n+9dycvCQUp/0a6ZAGCSpu1wBLP9xXfX+AZ1klR8k2nkv6PlZ\nqlKUS+DfEfXOyT+HEfVxcgAel1GRQ7bWPmmMuQjArwF4BW7U/wyAe621u9upc15PXKIc8vCjLBA+\nXa4JoPjF3a0gRFb8EQ54O6uk+XNav7iGaTU2ImK+oe5KdTWRD0ZnXt+6UutldZQfa0+YxI1f7X2g\nF11btySY20VVT4/ez154+ZvUl0aHdQ3WixXlkOcOrLWHAXywW/XN64lLlEPuLuoObKoUcEtpTC1z\ncLNWu1xX/faro5gO16x0LkM/x38EpDwQygqofHCxp0Q8FBw4nwQjKx8Xjyh/W17hlqD8Bxr5/q2j\nc6UP3K6aJ8etBKakYaeVYtlzb1fqWhF2F1+yDwBw5JlgXLrReVcOHQgeF5EKXvyr+xLbWeMuiJ4l\nkqcPuGj1f7Ds24lNjj9OS/yv8cH5u8i7sjyl05xGksmesGYsLE4dXuoD/59RluLZs/Cw2+w+fkGw\niWeEvSESEM/nflGx/VO/vZNsIpfM0scCfuZ8X1KZ6zVJbQHLFkvgv9yWI3RMbFxeni8RgwCAz/rt\nO6iceBI/QbZv+nPEYwjQc8a/jbxksD5mbFPHguJyygdtQZB+V6AJZVT+qJZyeXllRtGYVyUgvB0x\nk16U7z7yAi+M+qI01f5mo+JhGSU55IhyGGPOAfDPALzOm54GcJ+19kA79c3riUtERERERERERERE\nuziFBQMIzu9ve+3CGPNTAP4ngMMIJOJ/A+A/GWN+zlr7l3XrjBOXiJFEq1iPdoLuy6gWSX0V8i7k\n+8C2ZsVzmwWeiOrI5YoZMVTNcxERMWj0O+i+E29w3XPbaasb+VmK7tkwB5fnA+ybtc7Tz9U9a93+\nOw7eAxUxR3EvXLLJf2mtPQkAxpgFAD7sj20oOVdFnLhE9AWdBTEquQ5SqBLkmZ7A5PMvaC8HhQaR\nyruwNanL9ZPbyAf2l/OPlZwtKVSlhejUDQBpSshNvj2m0ih9Sc7hwH6h9zA1RyhaHOS8JdRjP+a2\n6mSKgvJzlBtNCGBd+r/2iYKPGZ+7ROhhjCs2fitnW7QscCgOvcftHzsSKl467ihlzx69OLHNHncB\n8Uco070Eye/cFTraWNMEkM4L84o/Z+f2S0MnlvocLI8FkwSmf+/IlcF2LeVqEQgF6j6ybfHbS5vB\ndm/Dbc9DHtyusMuYziX0wAmyCW2Lz5VLZ5oZUfYSaFnv5XYw9UyOi6AAB+tL+4fINtXItyX3Z4Js\n8rxqtDChUwJpamMCharpg51bZ7ovhvaxz/SebsVrVMuxoo072/I0VGylwP5m7oxwTVXpT1xHnh6c\noGJwea8+yqtTi0uuocv9GOY65ypO4jSciMH5RVgH4Bdl0gLg/2fv/YP0qM700KcRGUljgQRoJTGF\nzQeoAAvLwRK1NlzZd/Z6DcYhKdvZbFDKtbIoKkVMNmXdi++9iV2R2Ys3W1l22U2tN84tx1iuJOOb\n2rWJi2vB2ilPdln/CshaBmPgCvgwlIRkARo0mUFjjfr+0ec95+3ut7tP//j665nvfaqmuuft0+ec\n7q9/nfM+7/MiDMOlIAj+EJFMcmnowEUxksgL+i/rrakzm9pW0Oaw4TtLWml21zu5qEIxeHTZI8BR\n9KFdvb49gs1X7r5fXL/gQR52IHkVNJm1PunhKvLWFPVnOZw/xbLBIUSxLc8m7O8E8DdVKtSBi6Lz\nKAri992H4B7QbOYwNwt1hdmywmDavP6bcgvw7B9vtxctb2f1PygMxD7bj5Y8jwtJI8cC5009fEaa\nwPeVgqxpBl7ymojSxwXlqC+8f8k8NNyLYNqfu4xN9ZtjPMxsl2+L9INfOsoC2AmnVtvVn721LVp5\na8za1l92HABwHJtdN7EAIC6b/F8P/Z2o/Luca8EG4K9h7R0xP/S7mI2yxU8z2yumHPdoUPA593oR\nnui5dXJA8QD3D5sld0Q9bJbMIWT1BHifqR7Jg8N/e7oepCD6vax/JHV8rdAG9YXLeBPuY+skHsD7\nROIOkiYCp2WSt0jaV/IUck9mCVqmX8C+vF8d1BEKSD4HZflkXzGCon725A1MarrrKPPeSB9T3qCj\n3uRWVXU2hYwlrMJSy5/TbcfUlEEQxGR1/g2APw6CYCvcG+Z9iKRR/s8q9evARaFQKBQKhUKhUDSB\nwwBCAHzK9V8L5f4ToviXUhjpgYvmcRk82tLPT7aRjCepO6OUT3moQ6toppxCoVgZ8JZQT4h3pGJr\nMrw/zVKU5LpkYZLBtDto70tbbTUhaLCSoHlcljUE+kJzGOmBi+ZxUaQhBfF7vnATtKXw2/HNWWID\n2bld0rkRfPjz0QeMVB8DffQc7KdtHJaqxfpy6/70vnTsnDZD9BquDMZyxeTS4Oiji1PFaJ33kyhD\nlI+D5wiZNMs1LJB9nWnsLWd66WnDSXrI2cbuejNa2eIy3VMg/tVXuoQyFGAvue0vwGm7/lovqo8H\n+9sM9+9zbWCNoaH9U3ZSiPbEU7tQjpWYQIJZbmA2Clh/itmmzXKS2fh2QjqVjAuSn2I2onbxdl80\nS0kv5kts/cu9aHmnUI6D6FvUJx7ML/WT8tJwqhrtw2lmk4LN5hoSJicyKI5eOTU6pu7nQxeqQnWS\nz0H6XMl1ZLeXl9elC9SxOnlkZEEDIZbnG2blE4myKYECv/NdpkzbWE55XFQOOY4wDF8aZP0jPXBR\nrDyUDZQftEfDxzNTSjLT4+MnT3igS1BvkkJRDN/7uer9VMZrQsiVjK+BrIFfWgUyvU8bHv2y3pc8\nZkDWuyEdWM/OxZ/3CtvM7kN+wtSq5285CiMo2kUQBBMAdgHYBMTl0MIw/Ddl69OBi2KgaOshlvRa\n5M4U2tl86cWRDIjcn3EM+UGr+ZBmY9n+C+mXiX05iH3mEAI62WAnOTMX83aIGbTNuf0IOwfTQqGD\nffNxIWyLScnuyfFisePJPQes3C29aEniAFy2mWbYv8k6RfLAzONCHpmxu5yHZPGZCwEA629wU/tr\n10Un7zSTPiavyhm4gP1Fs36KuSCuuvh5AMDPnmaSxoTvOgEArDNL7oGYNkvu0die2Aa44Pd1zEbe\niIeZ7XPGA/Vv2XmhgP7vsnLkreFB6lcktgFxgQDC+8zyk8xGEsbTBfsSuKzzRYlt/FwkvW6AOz/c\nk0LeKe41IRnvu1i5mFclgZhXMk+K94DgISh+jmSjwPu6IHzwi/dQ37M9P+R5keNo8j2wR/zwXt44\nkHqHifiBWaau0V7svzzvlKJ5LOG81j0uy0UOOQiCTwL4dwAWEUmjcC3/EFHwfinowEWhUCgUCoVC\noVA0jf8LwO8A+FdhGJ5rokIduCiWFdqeQZLoWT4Jz5rqZ9PHm0tD6CiWS14MxeghPx9Uv/S+pUQ7\nOhYzw5EVh5KV9HclBNgP07uRpMtVyoeVw1iQzl8RnU4pYwqDcQBfb2rQAujARbGMkXwwetO1JFpF\niURdpdqKQaIDUM4W3wGE0Gce/H5Efln4BexLFDqDabaeR6VJtpspKCAfr6OAmO2cmkPHKdGLiBLF\nKUVEq+CCgUQdYlne1306Suwxd5jlezkcLWZ7rsJ3TjwNAJjHWmvbYDhTr+ESa5t5PeIpLfYvtLYT\na94RrTwDh55Z9lNHEw84J7Yap3vdjjTWCTbadyuzPWIoYjz3jkTjup179COMbYiocUSlA+Byumxg\n5R8zbXDxADp2np/l+jBeHnDH8SFW7l1GwOABQ6v7MNsmiRdI54JEAV7pOdsrQPgvgOB+Vm4GaWw3\n+/Bg/wxqZQTh+mb5R3guKQleeajE+5BntZfyX/W82ioKsE+j+rNUxgGvD99BfRw3V286riSvjXgZ\ngd4n5dMqON9+x9JMXphRpaYtYRXOtk4V625wfgL/HsA/APB7TVUZ18dpAAAgAElEQVSoAxdF62h6\n9quOik2d9lIPa5/A+SFlea8TsF9OFCBp66fUyurMUisUTSOWKm3QbbXwYVfmeRQr31HkKrWJ5ft2\nXRqo1Qmwb/Z9VTRA7dequ04ZhaJB/HMADwdB8GFE00K/5BvDMPxfy1aoAxfFskIzgxDpBWiCxhMf\nMeGTyReI52yi5L0gGWGxDslWEMQ/aeqbZtsl+WICzRoDwIwgRrBAHhJ2jqn/idllH9qH3b7QF4Jp\ni483k67AvUp0vF8wZXnQNq3zbPA0K89m7OdOmWD7HpMlfpUFzBv87Og2AMD6jW9Y20tPRe6D9e9y\nQfwbLo68MCdOuSD+TVe+HNkeeke6L9wDQZLMPWajQHjuUSBPBs8W/ydmyb0r1FUuE03B9p9DGvz8\nvWW8IMw7NfYbiwCARXauLp04CgA49o0rXMFfZ+eSsMWc02lmuzat5jA2GUlHLz7OvDoPmX2piT9h\nO5CQwZd5vWbJPVzkVeFiEZInhWwz7Hqk7aKXhQfiZ4l8+KGql0EUxYj1texzs9xxSJ4CnzZ8vBAO\nvC/VpIcH+dGeJYDQRF4W9/ykugWxhlrqXvkeLtk75GcbBURyyO1+TndZDjmBf45INudZ838yOL80\ndOCiUCgUCoVCoVAomsb/BuCOMAy/2lSFIz1w2bdvH9avX28THSmGj6JZo7pBh4Vtb0+2l72vBo3L\naIruFQT3Mi+VQtFdNHbNm2cKCYCUCYr2qr/FjPNyu7IYQfUcIn27XsWzUTWZpdRuHqWt6Dcr+l2K\n6HIrkSI2NTWFqakpzM7ODrsrino4A+Cvm6xwpAcuDzzwAHbs2DHsbowcBvfC5O7upNuePfCJbiXR\nPmI5R1y9KXD++Nr9Jvi94MXAM80zpGhXjNIVPhkvG4uROShx2SW1MGPjmcAtlU3oUCzoVwiSt/12\nNkdV8cxvwweItl9S7gthH/4b7TX1P2b+v46VJ3rUV5ltS0RhumrCcYOOz28GAMw95oLzL/94xDFa\ngBudUs6WGN4VLVaPLVrTqdc3pIqdOGQoYjyovG+Wh5mNtn+S2YgWxvOa3GeoWDwHDOkDSHQ5nqeE\nKGdzzHYksQ1wgf3XO5M9R0zH4PSGiBJ39cfdxfrc04ZzyfPlbDGsgE+6c0W0u9lTruFLLo7EEo69\nyqhik9FibIuhkYFto+PgfZ82S06lM3Xgsp6z0T3EB8gk4HArK7fLLD/L6rP3UJ8ZZbU+KXdRalKm\n5kRI1eeqfM+RkEjzQfd14Eel63nt7/shX/68FgsLlDmOWD/tu6vG78LfFyWEVtoGTSgfOnQIO3fu\nHHZ3cqF5XHLxxwB+G8A/a6rCkR64KFYe7MtfVA4bYLu1ZkH7HtvMy2mZeSCi/jfxwaNQLF/IwhXZ\n3oZqnmW5vuLZ/n7pttL7Fsdc+PahyHOSlXHer50SctMMZQcvPsdTJCdcpd068GlXigFVKArwqwD+\nlyAIbkOkZZkMzv942Qp14KLoFOrMVBXNWKZmsGKz/n1hD0FumMqJAef5Er+2n7FAWmGfmZz6DnJJ\nVdi+5NYnwe4jlecfIWZ7yjuV/B3Ssp9ZH0TpDyuhEM0KJrxUYdhD8Ls9ZyBvBHkMPp2uat21J+36\n3KuRW+I0XOD8xHgUXH7qZpeg5wrjDnmRRck//0IUnI9XWYdNkPq6Dc4bc+nFUX0vPc6i7inAnQfi\nc48HgaSF72E2CjDnUs8kHsC9DAQuBdwzy0eYjfZxegK49FMvAgCOHWIB9lSP5MFZ42IqN48fBwA8\nd/Qaa9u07ecAgFVYsrZjL/TifQeweeJEtMIkrm25d7F2jRfEelpeZNu2m+UlzEbn+25m+6JZclGC\nLftT7QNA+KnE82Sa2opfu5F4hyy2kfZk5M+SS/QwIP+Z12jQuahClh6Q1EX+eckuL8NPNrla3Xn7\n9TLrqjoQ9BrssWe964PfMWRdK2UHmYo0ouD8dj0uyyg4/xSAbzRZoQ5cFAqFQqFQKBQKRaMIw3Bv\n03XqwEUxNGTN8hRRHdJSvIQcSV4cSM/sz0jtyx4QV59rg9eXPWu1x/Vhb88s9yP8ilDU1ivElSzw\n7XGXfrH8Zl6ugHsT/7t6JXsWuPcpfV7y9+XSq+lji3t/gqAfl3WGmfX+jPmHSfdSjMvcjSwgwyQ8\nPPG0kyU+sebt0aYrf2Rt5Gl56RvORUJxL4tXOo8BeSi488TGgXDPxyTSIO/FQ8xG3hUuaTxtljw+\nhsCP96NCfYTL2DolfWSeo9deN+6KNawcJX08xeJoKP4Dbt/jW6IYoU0Tx62N4oGslwqw8sqbdvzc\nmsjzNfuUcx1dviM6CS+94Dw4OGnamzb/cy2Vp8ySSz5TTA/3zJD35TFmo/p4oszbgeAOxH8D8ujN\n5N8v/F7k8XVh2Et4hF1cXPKaj8VhjBvPT26yy/hsuh/VaA9SNK9UvNv+Qo+Eu+9zixX05UCi/1H/\n8trjyMsan05SnH88dWhaeR4kb+ngwtw71T1MZT1B8dga12Y4LxQecSzhvNYSUP5i6nv4xdT3cHb2\nf7TSXhehAxeFQqFQKBQKhaLj+JXdv4Zf2f1rmDv0/+HwzruLdxgygiB4ETn5WsIwvLJsnTpwUXQO\nTQSTls22XBdlFYHyj9G/z1K70Qxtn1kET1TDUs5lOdJ1AmzFuu5ZXqIFipWFovspCO5NzabnBexb\nFM7Ae7Tb2P7pOLZRRx0RBaCcB2hQbcj790u1wTGqSSgVmfijxP9/C8B7EHEIfr9KhTpwUQwN1dR0\nioLJE5DkIxkFywXE9ovrAlxwLqfeTEt9O5BYIi5nm4sDIvUsWz6VtVH2Q8dIOReh1suoqE/2N/Ks\nLyakkPi9+O/yebPklK3DQcp2+c1RQt/Dh95nbTagv+fKvXQooo1xqtNY781U9xYpqJxLFRMTilO7\niIXGKWAURD8nlONB5beb5UeZ7ZRZvsFsD5vlJLM9Zs7BrvQkGMkNA8Bi3wTC/9Bt3/Sp6Ni5NPTz\nRyNO1fi4u5BIYvqqK5+2tnkjLX163gkj2H2cfoI9z1xK+dKbI87X/ORaAMDsl5kqAdHB+G9Pvy+n\nj1EA/i5mk34Xoo1xqhhRtWJSsoItT2q9aDJBevYtEE213segb+B4XUnlMnU1lXm9LB2sbJ/K7p/+\nHf3r5M/i5tXF0tec9H+S4qgoxhJWYanlz+m2xQCqIgzDP5bsQRDcjZQsih904KJoDMOScawD/+SU\nplwivmJQkPqVsgm5VYrrTX9s5f1u9WfupJnmvv++CsUKh5e3BgWKig3dK/5ywX2zRh/D8QmlrLw1\nVWSGi6SFaXvZj+wuva98+9J0n7PiMuu2VyaR9LDPvWJoOAjgXwEoHbyvAxdFp5CVICwv8DIYTwcO\n2pedlGArI8dL9LKVbKwOmu2fkT0zKanior4LA4l8qeIC2BnaHjMKM7oFwb6VIc1IL3Bxg77Z6Gbz\nrE3aN1Z3z66639mco/tN+b2sDprLcY4UUZb4paNGAphJBs9RhkXmCcBWE9j/DRfYb2f2+Ww/eda+\nyGyPCeW+bJbck2K2j93GPB8PG8/HnawceVK4ZDAF1t/IbBSI/2/ZBfkhszzlbIuU7JFJJI9NRn0Y\nu9YljJyfj76yz5w/Zm2URHKDdfkAF4yfTtnejpcBAEfHJ6yNJJSvv9m5dcjztf4G15lj3ze/UTq3\nJ/Axs3xN2MaD7km04AizTQrltgrlrCw4k0H/iLnWxMSyBd5XKbGr4P2sMiDJl0/uifX6SeKSJ7hf\nuk9NQvYODAdNeIiarDtvX//6ClgHifp0gknlkCviNwC8XmVHHbgoFAqFQqFQKBSKRhEEwU8QD84P\nEJF0fwXAp6rUqQMXhSIHtSQkhwSpD76zbT79b56WUt6z1LS4gELhC/tMuLU3zG4Ui5iwe6QpCduo\nzeYETzKPIScuro6wxyAodb4B9sOmRIne/VL79wEUU/K68A5UdApJgf5zAH4BYDoMw2eE8oUY6YHL\nvn37sH79euzevRu7d+8u3kGRi6YfzN7u7hitiLanudeOJrEnUYbtG8ud0hfK7UkspXqS2w2EF0ZW\n0GzWyyFWbiH98iz/0ig6jpK/a4wWJmwXg5fTuQly6X8xeo1ZnxT6eLcpzz8wKQ8Jz0x/pwmi/zSz\nmV3xA2abC9I2ytrOqUZUN6dsEeWMZ7q/zSwZPYvqWZy70Nm2CuWINraz72xf6EVLHuxPFDH+eKOg\n9y1nmI2oX4w+ZoLzF1mQPIkGXH6ze98smKD7577/bmsbuzaimV1yseNvUW6c1XDUs8snosj6w99w\nfL5NH48EAE4c3ezaJYoYNfthNoF3xPR5kvVz2iy5MAPVwYPu+e9GIIrh7cz2WaHcQflDMMrP0meW\nPWnKKfxiMgb1sVtcr/TcpHuW36/l+pdFBc7F2l7OwIs/s5ZvrEQb9DERdO0WUoezB4hVflOf45ia\nmsLU1BRmZ2e96hwmzuG8IVDFzmu1vaoIw7DxkexID1weeOAB7NixY9jdUMA/QJyjyQRhdntN+VG5\n3n60wj64iwNO7wVuTXwQfbvxrnlj0LNoqSR7onhAczO9CsWgIHklfDwVRc+E+n2iun3iWarXT234\nlKtaf1GZNr0bw2hXPB/iAHr5ej9oQvnQoUPYuXPnsLuj6BBGeuCiWBnIf1lI0sJkE4r75j+Jlcvy\n4OTVne6nD/gHTVJIINqe7XkppjT4l/UpJ3rM7MwpG5jk0b5EWVmBKrKlFy35DDoNFLn8LYHPul9n\nllyCmGb2P4Y0LmLr0oz9M4klBw8uf1HYTh4h7pmR5Hl/3XhLuModBf4z+WLbVyY8YD0TdzK5ZjpH\nXF6Z+sIEBS6/yWS1J0EDAFdNRFHsF9z0U2u7FEcBAItgbRhcwqLoV+EsAOC1D2+0trWILpJNE8et\n7dSa6MQtvmU8UYfZxUqeKO6F2RKk+m5/X35uSTqaB9iTuAI/t9t7CJ8EgjvYvg+6gH0HKRDfbWvy\nw7awLtFjnIe0MEkd+Byrl+y7x7OsyZn+MvX4tDtsihhHdl8KRHE8qbldOtY2sTSE4PyuyyEHQXAO\nOYknDcIwDEuPQ3TgolAoFAqFQqFQKJqCNO1HuBHAPwOq8d104KLoHMq63guDVH0yVPu2MQAqWdk+\nFCXu9KNppDns1frUb6QehaLrCIJ743LbQ+tHX7Snc6fUo1am6JuxPpR93ijaRtb5LxNr1cR7T3O2\njCbCMPwvSVsQBNcA+D0AfxfAfwTwL6vUrQMXRedRRytfjo/IoYAhTWdK5j9J08xkWkhWv+TMymma\nRvwFk64vKycDtVMW5fdpKOYkgw4WnSs/kQNLp5pktunENsAFXN/HbBQk/3lmu8Usv8lsxHDiuX6J\nYsXywuATZsmpXVQfzw1C7T7MbPcINirHA80fMhSsLzEbUaF4ED/VwwPNTb6Xsf/AcsW8FdXH6Vkn\nXjH5alwqFrz0QpR3Zf1lrtwYC7YnPG8OfsJQxgDgfCylyj2HqL7N466+55++LlXu0m0Rr25+XXRz\nzm5hfL0HzLl4ld2UdC6mWSWUw4f/LsR447SwI4kl4K7RB5n4xIOeohzeaDrQPP2cy/o/ibKqfWWe\nHU1muncYTvxbvXwpzbRrn//8up6pPlgQaXB3l+7iSGEJ5+Fs61Sx5RGcDwBBEEwAoEC/RwFcH4bh\nU1Xr04GLYkXCPwN0+RmlppOeSR8JfsG82cdYJkN1FWGEuvALtu0PpG2Fog7qXJflM9P7ezK74uHw\nlmlmsUHLOet9WXSt701NfCkUSQRBsB7AvwDw2wAOA/hgGIZ/VbdeHbgoOoF6D8q84Hjp45/kSdOe\nlKK+uQ+KfOngvJd3rD56iTPJTy47mrVfXp1+8A3YTbfR/AeS9PsZG5c+phnFmb6z0Uw5eRTecJvs\nbPstzEaelkmhG1wimQLTeTD9XrN8kNl+ijTuN0vmqcBjQjkK3peytvPZU/IecC8MHW8su7uw7+fM\nctqZxm6LPC0kdwwAY73IduKFt1vbrpu/AwB4DS5wfjUiUYCnX99mbT87dT0A4Porf2Rtx17oAQA2\nX+k8KcfnI3nj+XE3UqdA/NO4wNo2bYvkkM8sjlnb/OJaAMDsK0Yi+S3nXbn09yNvzLHvO8EAi+vZ\nOv0ePGB/xiz5NULnlM8y3+87o5+WYQckGpcMn8z0eZ5WqqMuJBGN8hDOQc38S1mKaEpTRfy5mCtf\n3LPr+dckq+N+Vu73q0tgr1REwfntfk4vg+D8/x3A/4GIA7Bboo5VhQ5cFAqFQqFQKBQKRVP4PQAL\niKaC9gQi7xsIw/DjZSvWgYui8yhDe6paZxfQRJ+UXqVQdA9NPm9K02A9kKaI9tm2XqatSlsSApe7\nNJKd7uDzWVGMrtHg2sK5Icghn+u4xwXA11Ash1wJOnBRrADkU8SafcmWpVgVUEwKMhZXp4ftSR13\nVobjonqy0VReCimvjpB/Z8ZQRcZ7zNaPlkeMbZJVQetfZDai/3DqA9FhXkEanFZEVLIvCeXeAMLf\nj1btR9hdbDvlDnmQtbvLtHs/K3d3P1p+oeds02Y5ycoRnelxZqP+8fwxXzbLzznT4tcNRYzRqBZP\nGaoWo2Adnn9PtO0tR9miIP4bJ75vbQsXRzQuTve6/MpnAQDHsdnarhmPbKcY/47oYxzj4yYA/4hL\nuLKudxIAMLbhdNQPRnM79qeGIsbzs5BAwQ+Y7VGz5LSw7WbJ6Xp0riR6XwwC5RT5CR79qKS9ooZz\n6+4CvPpi6LF80NJY3R1G4/3f7uoLn2yyL+XpxAoFIQzDTw6qbh24KJYlygw+aKaw6IMgWa4LAbJF\nGa/TtvLqOnVmydL96yf61ytdj7P10wU7jFhyQsVIYBDXbdV7qF6bPlLr6WdLXYGQILg39uHt28+i\neuv0aRD7riQ04VUZVc+MohnowEXRefhmYJYgf0TkBIMXoqwnJ98r4av25Q8/L4hvoL300dRMkL4s\nT53envYcxWH2XTD/HmT9+11j28WKf7YfLW9l54hm6m9j5e42x3aXcC4lz8xrgo0H+1Mw/ROsvimz\n5AIAXJY3CR50bySN8SKzUfA5r4K8B70zzvZNIx/8PmcieePxsQVrGzOB+MfemnDlNr5hmnKdJslj\n7nFZQBSFvQ1PWxt5X54/6g7kqokjKduq888CAK7f9kNrO/wXprNbDfNgDRzWJZaA80Tx35SEFJiS\nsv0t72S2vy9c15S/5UFhG1cktEpZ+dd3nY81332z7lO/zPQ9YVv1Z5ktM+/Wbd0zaWGUolxVCoZY\nUH5vYM3keRJ5mVHEOZw3BKrY8pFDbhqje+QKhUKhUCgUCoVi2UA9LoqhQaQ9JeQyw/nsjO/l2+tX\nLpcn41klWLZ5T0t+HVk0szr1yWV86ST+v2NZyp5t7wujOfun6C4k2lWTVLDaQfIF95rPM7QMfaxs\nn6qizjN6kLl3qmIQ78SqfVYKHXAW52FVyx6XsyPsd9CBi2KZoohCRJDyKvjahNwDLN+K1KfkvvWQ\nfiE1nam5qX2zcs80kwE80W6MbmJWiK7DxQ6IFsZzwdzD1gkUtM0zzhOV7MVkYcRzp1xiljcw26Sw\nDwXg7+yzNkxftrNyFDjO26DA8duZbVpog8CasPSpV1c728fMcoujj1Eg/IZtLrL/paNR0PulE0et\njfKpcKrY0cVLAQDvGTtsbZSfpW9T0wOvmZN19cSzbt/5iIZGFDTel8MbHKdr/WT042wcizh5zz99\nnTueXRF9bN0Wx9ebmzO5Zz7vitnzdx+zkdACD+InWhi/HiSKGLLjuuI2OYg/C4P46PWheBUPELJz\nYlVptw668MwbRTR1/KN+HhX1oAMXhTeqzKyUmcEKgnsby2Df1Ms/q09NBuCW+aiJ1zHcAEefPg9G\nrKD6DKNC0SRE76ynLa+MFGNSFJvi68XNrqfOzH334k+62KdBo454QVFyZan+srFIOmBRNAEduCiG\nitRgJiUPvD/j4dj3bCFNyXCyuwdY+5Itu0/JNtKzrPl9KULdB/wwPDM+Qb8O/DxLv1HflssFeUYO\nmvL3sD6QDLINmAbwaFR/zENC65cwG032cznk+6mNXroN7g2hengQOHlc+L6fJhsrRxLKfF/yCnAv\nDPXrdiaTfyqmJx3f59X0JsB5YS69KXItbWQqA69tiLwWFHwPAC+PvR2A87wAwMTYMQDA09hmbW/H\ny1GXYsoDEVZhya5vHo9EAW6Ck1f+f7b8QwDA2nXOtbYwF7k9n38m8sZsuunnqfqOfcN5d6yniUtS\nP2yWdzPbnFnSbws4gYQZgY7DvXf2upJFPtLXsq+XuDqyJM/9kPaWDvpD069+2Rs+iLbqPDfbUH9z\nbTUjXiApaDr4ne9619zKwDmcj6WWP6fPjfDn++geOYB9+/Zh/fr12L17N3bv3j3s7igUCoVCoVCM\nPKampjA1NYXZ2dlhd0XRMYz0wOWBBx7Ajh07ht0NRQ7y8gtUrauKLb69X7HN4VCc2qSUNRkcrFAs\nZ9ShYBU9l7Ll38sHodfpU5l9fPvsI7vr2+ZKQ62cWyxWMztOszyaOt/JY6MJ5UOHDmHnzp2NtDEo\nqBxyuxjpgYuiHKp89Pq63ssquHC3vJ8yCqNBSIHcyEvm6JfvpZgq0FSmeWpvuHzhMu37BwAbWErO\nfvuStfvyXCfTif2+yNYnqUwPKfCM80S74nQqiv3m9CwKppdoXByWFsZsR4RyrwrbiOJ0itmmhX0n\nzZJluscnzZJnhv+QWb7LBeKPrYnWF99yVLHT81EOlvlx93Uz91hEFTt682lrIwrY0TGX22WD6ezP\njjqq2NqJ6EfjeVxehqGZwdHMFg1djdPMFk9dYPq56Nq9OGp3/qaof5yqNjsd0cfW3+Z+wNnPmuQ8\nj8KBKIE85w5t5xQwKjfDyiXzBRlEzwyhHEdebp4YCmiRNeB3rzZLxWpyADHsZ91yRLlzJl176fdV\nnZxqCkVT0IGLohMo+5Lr+sx8G7N+8oxu/sdP3iDPVxqz3szrnlyb774KRRdQ9T73juFqvN3BPZfa\nlAN2bZbzQDQt3VsmuWcTWeZj9hyJ/qZQRhyiTB1F56VJpoVi5UEHLorOoXxmdv7y93jQLdwrzJTG\n285uv7zXpDuzVF348D+Q9mzx2W5CShCB79t3JprNvswsD7Jt5GnhwflHjG2SVUvZ07mngnCJYJO8\nJ2+wdaqHz9hT1nYexP8K0iAbFwUgOeRbhHLTzMYD0Qmmr+snXQeXzkaP/cXpC61t88ejgj879B5r\nu/zmSBr5tfmNrrrzr4rVAQBHxyM5ZLw1Zm0XGS/M44uO4rFhLLJdwfSaH5+P3Bunxl0Q/6YrI+/K\nia+9w9rmdkU/BEkezxmvDADAdI88LwCAf2JEC7azm5y8WZ9wptjvkQK7X8SAfYfcj7oSmc2rKjVK\n/5cZpMj0LLlu37xMZb3tRTZfrOyPXUEkgrB2fz4FLPZMzT9HZel6K/ucF2MJ5+G8lqliSyNMFRvd\nI1coFAqFQqFQKBTLBupxUbSC5ZJdtwoFzZcOMOy8KxJ8xQOapJjUC7ztN9YPhaKLaCo/S16dXcCg\nn4fL5Z0DZP8+pQPw3832fbJOj4S6x5HhCVecO7cKS+daDs5vub0uQQcuik6gPP2qx/7LywodleO5\nQqq0OQh6WF3I3GBak+Je0nka4vCnwUlUgrJKR+mA/QPidldPHykQpeqgaWM724eoVV/sOdtWs9wl\ndIjTvX4qbKd9eOZ1ygmyndmk4HzaPsds7zNLTj2j9a8zGx0jS1NixQU4lY2OjQXiox8Fv1M2egDA\nW9GCB7OfJZrDFrfvBKL8LOePL6XKvXTSdWZ8POKn8Mz1lFuF6GGAyxHzIqNLXTDuAv8JJ45uBgDs\n/K2/trYnDv1PAIC5w4YXdi3bYcosuTDDfzA3wv3MRkH3nB72eGIbADzYj5acjkO/wRF2fX0u1fUM\n5N1X5XO7lKfSpveX7qWqz6xhDgiG/Vwuqq+J9rxztmxvti8x2qEUT+OZLHpQAj2K0YUOXBTLAsnZ\nOVlCs8/+7yX2qxffUVZKspZsZc0M2v7tZEuuVnnhUr+lPueVz+9fF+JyFIp8FAcb9+GrTphVd9E9\n6V+u7912FfhORHQFTXk7BoHkb9rmR308DnH456LLWFo6DzjbcozL0uhGeujARdEKhv8SKPI2ZJVD\nYw/tts5Bup38l57PS7Fo1qzMx5A04xuGPQTjrI0CSkJmxmce1C5ltScnA/eaEHhGdXJQcIlk8oZs\nZTbJM0NB8ty7QjP7vD6qh3tNLhLKUV8fYbbbzPIZZiMvzeNO5hifN8te2gvDA+xfevzaVDnKS3By\nMa1QcPXEs3b96Hwkjbx5/Li1nUIUbL8AN+KfN1rCpxZdIP7EWOTVIZllADi5MWrviaPMDbImWoxN\nvgkAWHzVCQtAyh38sFlywYKtQrnHE0uOSbZOog/cC3NfNIkh3TfF90a2oEhTmcizB1C0vVex5mYm\nEwb9PBz+O8cf3l4VYR9bLiUc0SCjwArasN9+oT8Q9bjl9LsphoPRHbIpFAqFQqFQKBSKZQP1uCha\nxyD0/qvQiqRZ/0HAl+bV5ExT1QDf7G3xcxuGPe/Afh/woFKv8hqkr+gAsq7bJu8NV2ffrvs8q7om\nGlI3N4dvPpD8XFXNBOxXyU2SV0eVPjUrmNJP9KGX0d6ehK0fK18lF1hb78RBYunsKuBsu5/TSy1T\n07oEHbgoOou8h5ZMp5DoF3uEbdXaLIM6nGTpge97Lnz6xNGc8k763OefA1aegkp5vhWi5y0UfABa\n6k6Uw0D8kOQ0IKJ73S2U47QvypPCA+wp0JtTz6g+nqGd9pkW2riOrf+RWXKhAKK63clsf2KWtzHb\nD8zyImaj7VL/TjH6mKGDzT3m8rOM3WAoWH1HwfrxqQ9EKxscfWxsTbS+6mIXsH/J+EkAwFV43tpe\nxtsBABM4am1nYIQCWL6VrTdH+0y/Pmlti1+K+jB215vO9q8inU0AACAASURBVEy07+Ip0z9Ow6P8\nLFwggW8nfEcoRwIO/LenXD/TLp4tGO/ZzdZmr7WigQld6+nBvz+KBz9+927JnFdiOz2v7VKerOWA\nrnwsl+9Hs/GATVEWFYqmoQMXRS20ITnZVKb2Km1lCwFkZDNucLaoyrkt6lebL+XsvvQH09445DgG\nhaIi7LXKYlusbXsPErwzipvwHzsQKvGcK3sPyUIc2XX4i4HsYeV6mW0NC13qC2FoAfYMTb8HpPdt\nUx6o5YBzS6taD84/t6QeF4WiNQyKkiWDpEilB6dvwH4xymYa5vsNClWD7v3q2F+x73vsMk3jYL/H\ngjmnGQH7KVoIfVjyLOX0YcnlhsnTwqVzJ82SArAB4B6z7x5ms+ilTVwUgLw1fBBFUst8tp/Ug/m+\nFGA/zWzkQXmY2aTgfPIy8O6Rt+kUs70VeS8uvflFazo9H2WiX2RyyO+ceBoAMA4no3cUE6brLmB/\nrdl+GNdbG/e+2DZgst2z433ihZtM/9z0/Pp7ImWC2aeYhDN5VUg84FXmQSLRAhfz78pzzwudb/6b\n7u1Fy+lUd+MewAVhImSmbyiTxd7c1Me/JC9bGvlSyln3bloco7wksy+afL75yuoWedeT+1Tpo7xP\neY9HE3LOMuMAKBec3/NqVx608nYPeL0L25CRVqxcaHC+QqFQKBQKhUKh6DzU46JY8SiSKy27b512\nI3s/0Zeet1BAYxmWa1La6pxTV0ef7dtLb/9Izr4lg/kVimFjkHkxBkkJauoZ2GQgfB20HUSfV0f1\nPvW92y7aPy20Qt5uZuDexwZR9I5sl51RHUtL5yFsnSo2un4HHbgoamFYGeJ9US83idlX+Mjw3rcD\naDp7s++xyfQCOVA51QYNWiaB8NtkNfXxQQtRxOjFShQvIE4HI0h5V4gitpft+xoQfgUIXuuly3MK\nGOVY4TkU7jTH8WVWjlhPPJM75Rj5OrMRzYwH2BN4OhWiiE0KfeH7Uob5w8z2vmhx7OiENVHQPb7r\nKFg/e9d7AABX73jS2o59/4poheV7+dWJHwEAjmOTtS1grbFtTh3Gut5Ju751/Eiq3LEXelG5a105\nKyTwkOnfOjgQRYzb6DxzcQU6f3t7zkb5cvg5s2IOrNwMrUh0nApB9yYvRhaafa5K91ovdw9/cZH6\ngihNo6qCYn34Cx8M5r3pJ+BQa9DD34U5g5lKx2cFWbLrVSgAHbgoWoJvoHlVz0OSV1t+1sq9dJrK\nUO2LQWeIrzNjWWbfQX0UpAI/M4KiG293HPIAQqEwyLp3s54t+eWy6o8wqEmiImnfQaOOwEtTnuN8\nAYJ20QU54CC4t5ZXcDkJODSBpbOrcO6X7Xhcwm/+Z4Tf/DPgzdlW2usidOCiGBlUlpdkGYKbCMDn\ngzEeWOkTNNpUUGPbL8TiD4NEfw7mnOcZ4feglyz3smx15S2mo/1is3pfMLb7kA/yjHCvySTVy/pP\n3pBXWDkp87qUrZ0C118VtkmKadyTQrLKM8xGYgAszt0Gs3/YeVcu2RHJFh+7wckhc8+IhfFubJo4\nbk0kfbwE9+I+9nrkzdlwsVMFOPH0O1L1Hj70vlQT5GmZe2YjM0aL9XeawP0vswP6kllyEYZJs5xm\nNjp/97Nri6S4+fnhYgmEGWHQPOPu3Tiq3lvVg+TzvTfV6oyQ701q4wN0UAH+Zfpetw/VRVCyyvfs\nupOdTl+H8jukJ9iE88K8graNmGS9qWfBq8uKhhB87DcRfOw3ET55GOHNu4p3WIHQgYtCoVAoFAqF\nQlEB4blVCJda/pw+p3LICsWyQLPB8s3Ss5oKwKwbqNnFgMaiYypLv1tpVAPFyoFvDIGcifxe4NZi\nGm1Zz0dTVKi8oOmqubOWC+rm1WpCnIDqqZTbjMUGhk8mtmVcs02LoJTtd9Svo0XFFCMGHbgoWoE/\nhanXeJ3ZKAoeTQdblmnTr+zgX/J1zlMeXa1usk6fduUXKvtd6COPqGWcl82pQ4QFIffGG0JQKAX5\n82D+SdrGbLcnlgDwmFnewBs29d3CTERZ+gLrM+3LqUs8KD9Z7jZmIyob69/YbVH2+cW3WN6TLWb9\nh870Wi9qZP1Wx1FbmItkhZ47dU2q+fl5Jzl0wfjpaInT1rb24ii3y0t/ca3byeRUmdtwgbOtMUtG\nq7MUsadYg+Zczj5uTsyp9DYrdgC488fz3NA5+yI730Qz47Q9um4W+HVr7lNGU7RiEYW5LfLugwP5\nNKFb9yP8dn0VqbKQJxfSfcgS4MjOneXXVhtoWhyhaRGU4SGiLMYGLdt7CJ9M5B8i6uVlRUI1fbPG\n74kcAQeiY3KKr0LBoAMXRafQZLb4QSBrVrFLXo6k9yJvpq1snWXLlJ5hYy/GcD67XB00k/xPMaqw\n148Uc9RWH0rPXFctnz+xkjegGoR0u08dg/JylNmnav+a9J7nebGrsA98A/aDcQz13hgKzp4HtCyH\njLMqh7zsEQTBegDfBbAK0XH9mzAMv5y/l2K5odlMw/llS7/0MigeeZBfTGW9MMORHQXkGVefQFPx\ndxEHFAXHZrPdC7OENGPHA+IJ/AX8qNAWzcpLL+C72TqJAUjqYw8W5O2gwPA3mI08BdzLQv3j3hry\nUDzMbOQ9YAH7i183wfb8OMgjw2SYF++Jyi3e6YLzbdZ5FiNPuGTcBdi/9PS18T4BwLuMXDILdB/b\nEnl/xtYsppoAmEfoVGqjC7K3s7xsG3lIXmQ2vk6gc3t3cT6VcB4I7kg8D77iM+ilzOGSBHF+YLhv\ngH3e86vNgPM4qgsL1EGbHopqbQ3Go551LeU9e2nSqsjzZzEjlPsPbJ2+rrh3mEu7E+j5u1Xyhuec\nU9rv3OvAmexiitHDihm4AHgTwPvDMHwrCIK1AH4aBMGfh2H4RtGOCoVCoVAoFApFaSytat/jsqTB\n+cseYRiGAN4y/641yyCjuKIC6ujtN9WmpAlftF+ZpFtVjzEYRzwZ4IBQpn/2mFvKe+La9RMpaDov\njE1aqVAMAEHQl713Xvtm52rKpw4NngbbVN4Q375KNDRJbr5JmnBTtLU6aPK3rBSc35B4jEIxbKyY\ngQtg6WL/DRGh4DNhGL4+5C4pSqK5DO15aDZfgqWPpHKPVKWepUUBSveJD9RiAcXVUDUPQZkPMR7T\nksrPArhgaSl78629aMkD8m2Qp5C3g1ONrjPLGfZhOWmWsd/UbL+sly4nUiRYPyXKGVG/uAAA0S54\nPho67htYfdR/TlEjahWnblBXeUoWoorxgHSiprHzd/lvRZHtL32NBdib43jpkLNR3pXFLWPWtvi4\noZyxbPaLMHS0DYz38aqhiG0Ine2ImW/6qFCOAvY5LW1SsNFx8Hw49DtvZ+cxh04YfsWt2/uJCzjY\nfDlFdCCJ7miojRU/ZrNoYVXzlOTVI9dHYiW93LaaTmjZVp6qpoLzs85PVv1FOVZk5NMS88vnUXHT\ncZzBZ5iBhEG+xGxEo72C2YjOOi00wZ+LNyRs9ExdgCy0ohhZdGLgEgTB+wF8BsBOAJcC+GgYht9K\nlLkb0St3C4C/AfDbYRj+d14mDMNZANcHQfArAL4ZBMGfhWH4izaOQZGPoky6baOs/O4ooNZsZ40s\ny2J9CsUQUUc6Pc+7kt+GP7L2LVNnXllf+fKs7YPCMJ4Rdb1Adc9P1ruzqGxVRUdXT7yt2KBFEcdS\nAJxtmeCzNLqEok4MXAC8DVFI6b8H8I3kxiAI/iGAPwDwjwH8GMA+AI8GQXB1GIap9M5hGP4iCIK/\nAfB+qT5FNQw72zogz/o55A2I/ALYK820WU9BM+enCZnOLqmccdSRk3bZmyXJ5b75j/3OM8JLnrwv\nR1jdKU8ZgFeEfko0ISsOUIAZ4fq7xbTBPQW0HstQLfTFtsv6NG2Wn2PlfmCWrzHbq0I58owwb81r\n8yYqn3uTbk+Xm3skKrf+NufeGNsVBeDPfZVF9pMH5SEWiE+zqz9kL2HqyylWjvpK7fKZ2mmz5PLT\ntM6D9EnkgHvbbuhFS36MC9LHnvn9JG+f+GzhMsfIKVf+fq8jL55Vh899mRv43ZBMfBn59TJtD3uC\narDt+4uzhOH+hIBJDl3viz1Xju6ji9i+5En5PLNJckiScMkWwUZeX5It/6pZ/gzAJ4TyipFFJwYu\nYRg+AuARAAiCQBpG7gPw78Iw/JopcxeAvwPgDgD/2tg2AZgPw3DOUMY+AOBPW+i+QqFQKBQKhWIU\nsQTg7BDaHFF0YuCShyAI/hYiCtnvki0MwzAIgu8CuJEVvRzA/23GPQGAPw7DkLPHU9i3bx/Wr18f\ns+3evRu7d+9uqPeKItSdvfOp11dTX4JvjEZ7Ov/N0BDapHpIuQnK0B+K6/ej5igUbcI/cLxv1tzM\neZ7MeLW+pNsoX0czNK2mnz10bF31Mifh+86pe77lvFr9TLGWtpOcivjZFPDEVLS+z9hOzw6tO4pu\novMDF0RZBFYBOJ6wHwdgUzqbeJf3lKn4gQcewI4dO2p3UFGMQVEe4sh+KTfV/kpGEzly6tHlfEUT\npOBS3yBTU27h3jSVR4zTKRgQ0UcAz7FCgfWczkTZpaeZ7f6+abeX3wZRkr7OytE+17Fyu8ySC8BL\nUze0D6d1UKDtBqH8nWydurCG2UzeldmnHP+DAvZ5cL6lfl3vTGPXRrldbDA/x0NCn4nyxo+RaF4P\n9p2Nfhce1EuUFUlIgVPztsvXcPhk1sQBD4ineg6kysnPm3oDbp/cU1kfpHUoqcOgXpU5tkG322T5\ncqDril039/SiJT1PsspJoOeIdP3zoPu7zJJTL+83S36fEqVzmtm2CDYK4ufUszcAvHM38JHd8baO\nHwJ+slPsvmI0sRwGLgpFClWCUKu8UKruO6xBURvSqnLCs76xyApKCsVyR+YM9hBR1mOcta80sKoT\n3F0GZRTJBuFh9vVi+5yfvLqHHWejGCCUKtYqlsPA5SSin2hzwr4ZcbFLxTLDIB7kfh/S6fbLZn5P\n7l+2f/nI/tBv8py19yJN/gb74+e+MBt5BPu78OBS7Dcz4f3oX5JFBtwMnxhszbDX9IXLA9NM/V5W\nH23nAfk0s3+/ILnMZ/tpnXthjvTSNgocf4W1S54CyXvwUWaj4+QeA5I+5p6PZ5AGBdqybPVzD21M\nlyMV5PuZjfoyzfbFxpTNYldoVxenjaeFB8zTDG0siD5Rx91Ig//2JLhwKzsXVl61L+zMMOO258v9\nCvep9Z7tj8l7p8u5flE5KbqzSrB6unyP/dcMDakrWC70MA5f73+uh4nTvSTP7QKtCO+/y1i99Ez5\nAtuX7rsZZyIv6eWfcg+Pl44azeOPMhGNNdG9vf4eR5CZ/XJ0Q6876XSU5p4xz4c/YW3Qs2raLMlz\nfS59CIrRxnnD7kARwjD8JYAnAHyQbCaA/4MAvj+sfikUCoVCoVAoRhxnh/Q3ouiExyUIgrchmnek\nOacrgyD42wBeD8PwZQB/COCrQRA8ASeHPA4nmFcJFJyvAfkrB1JW5vS2pIRudjm/tgbnvfChc5Sp\nI79c36yVl21tGrl0tERwaVW6jm1jr1I4FDLaoILJFDRjEzwzdetu8j5umwrVRP4t3wzybYuWZJdr\nTshkWeHsFLA0BUCD8xVxdGLggogI8D0Aofn7A2M/AOCOMAz/cxAEGwH8DiKK2GEAt9RNLqnB+csZ\n8Qd4WqkqGZxYoKZDHwhCjpAqqKMMU5SN2qfdqturtuEoGxXoc2U/yGb67Bz1jdH8vgeFgU4s94Zw\nTolCxClbWxGnoAGOiiEF03NK0kFh8Ez7MBqStXEKGG3ng7PPun3scX9E6DPlZOB5E4j6xQPSKRD/\ns+xcfNH0n+eUIcoIp5kRXY5Tt6j/H2Y26vLnHC0MH6V5KYETxShqtq+8DQr6fQxp0DnguSGILjct\nlJNy6vBrZNIsYzl68p4jzLbA7dmB83lxHf4UsPx7rezzI4+W1iSGGdjfNEWudRED6ZlBFMminFJ0\njz/MbBSAP81sRD9l99O66yOa12acsLZbJqLESI9OOGWSl16I9JKWzrpPS6KXLcBxguceMSvs+TW2\nxQh1rDP00fN3R3/nDgFnOh6cfxbAL4fQ5oiiEwOXMAz/Gwpoa2EY/ik0L8uKQJ1ZujyPyiDQltRu\n09mW/dsrf2xVBACqyj9n79P3KlcHXZRZtvE9l+UWU3QAg7qu8+8/n/09ytA3ZoWJHF5/V2JQhh3T\nI0nC+5ZVKBRxdGLgolCUxwHhJSrJ5GaDvzwG97Jo9sN3cIIAVLaHepLGg4Qs8Rl523J24x9fNBPP\nZ/MfNNuPSJ6Z9HUW3MH37UdLHshKbczwjyVjkwLIJUj1cYizq+b8PMbKT5sl98yQzOgBVo6C7bm3\nhvrwGrORHMp9zPZDoSs/oCX7Ye4RypGnhXtLqA0uljBpltNmyWWgSaqVzyRfBoTfFtoDEIwnPCHz\niQ/bg7J3JSl9bOsLpHs8//kjewD22OXgPvibbcP/2VJdcKTpSZy6XvTm+tGz6+75VfC+mDRLfv3f\nL0xCSQIhBC5vTmIb/HlovK6X3+wC8d9tHgaX4qi1vQeHAQCvwYl4TFx5DACwirkDlsxnZt9qqUP0\n5lqhDhLvmDQnZRYazayIQQcuCoVCoVAoFApFFZxD+/LEI6y2NtIDFw3OXxmo4i1JUwfqeUZ8Azrb\nCvxsC1Vpf1Xy8JQv34y3K9W+BvMvC6RktreKxcoFSSe8X+GTJfpTgi4Ua9OW1+suiWp0vGqCJ0W/\nX76kfr5YjELA0Sng2BTwSw3OV8Qx0gMXDc4fDuq8gItpBT0APBt69H88aLZce3LisT6z5NFCiilr\nVGebyA5WLe5HmUBX3+OqW07uk0AtI/oWp2IRYh+2Et3LgGdolwJjjXhA8BEesG+2H2T1rM05Zp5r\nxAb0s2uJ9uV9vsXYeDZqopRcwWxEFeOB+BL+iaFsPMLoXkTf4vkXqA+PMBu19yKzTZvlJLOdStTL\ncRtb/4RZSvlbJApaHsQ8LnuQFnzwRZpSJtPH0sgO2K9KZ+rVrgMAo0qWH/xLA7Jhx7oMKjjfHxK1\nmSPnPG8XniM8z9MXzHYutkHPtz9n+xIdc4sTzLjxymkAwALWWltvW9TGKWywtusNLWwJq6xt3gTb\nTzD6GFHEnsM11nYaF0TL+QtcX4iaJuWU+rp53vzNjQBuBPAUgL8UCnYImoCyVYz0wEXRbWTNVqUV\nxPawffoD6kPZ/ZrtR5m2fGYC20QbwgNdm70Mgn48nkXReTR1z0qiDllCD01dt3WC6Uu14+ExLpPM\ntwlxjy4iV+Iay+94FIouQQcuipWNhXtzgmql2Xm/2Tn/mc3qQbBtvNya9n417WEpjZj0cd+sCJ4K\n/oFHNu5dkQLiJQ8JeS1iQfemXR5wniEskA2hz5NC0D0PvqX1SWajvnyR9Y8ybe9lNgIP0iVPCw96\n32WWkqoZ9+CQB+VVoRyXZqb6JBoXb5fkkEkUgJen3/IeLjZgbPx3pPMTyzAuTI7sNdsfTE+YyJBE\nQQ4Iz5GiWfc02pIo9mmja5MDQJVzkb7//OtIes8T+4mS+rLQQ1a7VjUQcPci90b+dS9aHmY269UU\nni1fZuufjhZXXfm0NVHA/G/gz6yNPCjHsdnaNuM4AGAMi9a2KmfK/3rWwW8uRvrKc6eYx+VBs7yR\n7UTPCnq2HOiZTr7eXb0YxVCgAxeFQqFQKBQKhaIKhpHJXvO4KBTto63cJWUD4n1mFotjXCRaiNsn\nX8c/n2oxbJpBmTwSWcfZ1G/fxVlgxWigiFqWd236Zm/PQir2Li9eKqPevGdLW8+bumIldfvZZPu+\nv4FYz7uLyygUiggjPXBRVbHlgiKKxQEhYL4YTWeyTvbJYdADjXwKw7AHOvXUvfz3Tf9WexJLyNQg\nyWYpWEL7k2ydqFhHesxofo8HmSmvHk4ps4H/vH/GdlCgj/G8K3Zf1pdbewi/nfjIJlobp3HR8X6U\n2R4yS54zgvI+8H1PIY1LzJJTuogCMsdslLn7LmYjagynrUkUMQKdi9eEbVbYIEI6/kvYh84jp5QV\nwAX2S9SgOtewJwwlNjefUU3UoYH6Us8G/6zyE0uRUNi3hfwBoBc4BZPuMX6PEwPremFffr0aauXY\nXW9a086LnwAQz7FyBfoAgKsY5/SUUfd4L35kbWcwBgAYZyo3RB87zDrzMt4BIB6wv23sZwCAJ9bs\ntLbFi1ZHK5wOSsf5HbP84ylgaQpRIpeOQ4PzW8VID1xUVWz5IWtw4pPlXJrVKiNnWqatdHmU2sev\n3n5ue74BtBzDGuSMqpx0Gyh7va5k0D1TNe5suWU1b+J+6ZK3Nw8+Xqpq+5p7Z3svXl/Ou8PHgxKT\n686Q6h5pnL87+jt3CDizs7i8YmQw0gMXxbBR9DGVt10KiGWwgZL9aJl46WSWR5RJm0P0zPD6jmTv\nmyUAUNYL0+UPBo7mpVClIGded7F3Kf4RsT/1wSHOktPEIg/uJg8Al0OmfRaKrmXhGr3O1E3B8kDs\nukr1k2d8n6S+CB9c01ygQLheCdzTczsQfiVxrv6I+slsNAv8IrM9apafZzYKCj7I+kf5b/hHGs2y\n8pnXW9JdTX3YcVECusdf7Tkb/W4Jj0s2BEnjZB4YD7hrPcubu9/WH20r7t+g7/08D8nKpmJmB877\novB5sz39vBFxJHp3BJ9hNpIU5/cpZZrnHs8Ph6Ycc7cZmeHrL3ZB8jfhrwEAm3Ei1fxr2GjXr8dP\nAAAbmQuTAvF5QD7JJW8ynhcAuACnU3X/4OhN0cpDq52RPEtcqIO8tHTcVlzlKBQKDh24KBQKhUKh\nUCgUVaBUsVahAxdFZxDNPsrc8EHRrcR+2JwIfbNSfUYusw3PQP1RQxN5c1y8gSCJS2VLxC8MC8Ed\nZuXrucWaa+8j7bTTBRQHx/dLXSNN0amy+jUIIZPqGeTT5XxFOar0zcE9+6vU37T3KPW+kpLCZu6H\n1PUVjENOsKpQKGLQgYtiaOAvH5kykT9gSAXECjSbIDB1XMZewgfT1A1LqfFVhpEyqvP6bB8lykj+\n4KtKboI6HwpN5JZoos2iD6fK7c7cm0/NsR8Q+y3Vzw5eE3lSwnkg+HqPGdM0QXs9xvKFCO3eL9gI\nNwg2XsdBuv7Z9UUDj4OsHF1r/DhsHex83ypQqy7rpfehLPWTzEa0j7/P9t1r9v0C+83uQxpEFeN9\nnjb78g9A6peU1JP6GTtuSlQrtFk4EWHOWeo363nsWw7xZ2D9wU/RfmUpYIOkqQ3qOUIoGvxE+2dc\nI/w9QNdh7Jmf8wyX7jUJUi4pSWCCqGAALr/yWQBxGtcTL9yU2uWd/yKie21mNC7ah6hgALCA6EF3\nidDwBqa6QbQwXh/lgHme3ajjiB6Cx7EpfRyc8vaD9GbbBaKe2nttGVDF1OPSKnTgoli2yOOH+8pL\nDorDXcajMuyA87IfTG1LpXL4zAxL14XvoLEoriEI7s0c3LYduJ1qT/qoH2E0LUowjHiP5r0EzR+D\nz3XfNTEQQhu/aRD0i2MsFQqFN0Z64KJyyF2Cm8lMfYjyj0lp5pr2nWGmZObzg3zWPScoc4GXI+Me\npOhHCfi8gJvORt2El6VLwbc+8tTZoN/SM0h+IW5NBWMv5LQvXoNSG5KABLNJVKQjiSX1bx4Ixll5\nqQ/kcUjUG87LAeLWy5IFymr/GLNNmiWfPSX5Yt4uiQbwQR7tyz09W2m7IFwhzXAfFAagM9JvL3tG\nUl4q8TpLP4vaGKz7eksG1Y8qcseDorzKz8p+uqAvkmItAMR7kgb/06wYeT/5+4XKHRTaWhCuW47t\nPYRPAsFH2DHS/XQnK7fBLI84l9CpyyLjRWPOG7Jui3FVfNjt+na8DAD4CL5tbeRVoW0A8DLebrad\ntLYLjF75azZa3u2zed4F9l8yHu3TM5LKAPCf8I8AANvwtLX96kQkq/zjdR9ACtzDS+fXPkcuAvAt\nQAj47xxWuMclCIJvIHqCfzcMw99sr2UZIz1wUTlkhUKhUCgUiq7h75m/pwD83SH3ZeTxRwD+PTqi\nqz/SAxdFN5GaBa2RkTheb79k+5I4QM4+FbJXZ9mHTRsbVPt1E30Oio7V9YD9Opm1l1vukUGi6bwm\nBN/60gHx/UQ9vcr9qoMy50VO8ipv983LVIRCoQD+7M3zlnYEwbsRTzapUHQYYRj+ZRAE//Ow+0HQ\ngYtimUGigAgJwuilMCO76iOwl511WfP6i8QB8uhW/jlbKmfLbgBV6FltD6rSgfWSGIH/RJBPTIxF\nYjAa0a6E8jEO+35DBWEmopTEAvbTH3iubnb9bBdoLpaqwmzUBzGImJ0fujemWTGJesbUzKzYBQ2g\nXkkXj9Uh5Wz5LG1nfbkvUZ7jQbZO583S72T1wbTN7x4uQh1qZRP7dhflc1NVPR+1BnUZg5nMfD0P\nsXXK5M6plbeZ5UF27ZHQxKusHNEtJWXAacHG7pd1n46oWHOnXI6Va8aeAwAsmkz2AHDNeBSwP4ZF\na6PM9ZwWtt1wsU7jAmujgH0eiH++4SDxgP0lrAIAnFnt2k1uAxxtjNsoiN8w0CJQAP7enrPROWLP\nkTDs4dCh17Gz6/knzwL45RDaHFHowEWhqAjfF6+Xt2YZQpZFrSbbmncOZA9Y36z5xrbktVVm335h\nGSCRSM6r3vbkvqsg+N1h96BZdNXzURWjIK8+EGGBbzRepULRGQRB8H4AnwGwE8ClAD4ahuG3EmXu\nRqQXuQXA3wD47TAM/3vbfS0DHbgoOgE7CycFSMd08c1sdiIjferj40jPbgMQD9Yn70qMGiTMzNIs\nMM9OboM8hVnthT4L4k9Xx9Fm0K8v2mi/SKCgyIslfWTGtxUPpjIh/X5ioK1wrcywvtOg5aDUF9Z3\n8VpKtgVZens657cqoiySl+aenrP91KxzTwoJBHyO2chbw4Pz6f64h7VLM6o8w7eFMEvPy0kB+As5\nAzt2H5MkNaHoPiyLOveInKG+V6M31ftQTxSknIhAvgsyhwAAIABJREFUGRuhTP/S9/getq0Xr497\nTSgQ/n62K13XXBxjr1lyDyBlsN/bczYSqeD7kseFB6HTfcclz423ZtPNP7cm8ngcvcFNrZO3hHtS\nyLvCvTDk+eCeFMpqP/GmC7A/eeF6AM7LAgAbfxG5Rt74FWcbO3MGSWxYFdVtPSpwwf4XSAH1D7N1\nOkecLkfvefvuXkZYQvvyxH7tvQ3AYUTxKalhehAE/xDAHwD4xwB+DGAfgEeDILg6DMOTyfJdwXnD\n7oBCoVAoFAqFQqFoDmEYPhKG4b8Mw/C/AJCmcfYB+HdhGH4tDMNnANwFYB7AHULZIKOO1qEeF8Wy\nQ5epVUV5QLzqKBHAno7XGJ4HR+p308H+ZXNzNPF7eLdF3hTuyeDbW+zLqIKLGFBcTqV6klnRS6DJ\n+7RLFLD85278nvTpa1PPqlyaqd5zCoWIIAj+FiIKmSUCh2EYBkHwXQA3Jsp+B8C7AbwtCIKfA/gH\nYRj+qM3+coz0wEXzuHQQCwK9JhbkLKjISLDZjs0LNZYXw+XycBQ1gbbzoPBCtIGDBfk4GPJeysOm\nh9VBVmB/E9m58yllB9j27NwWWR8t6Q/LNHUpP49EQX6W+z2vUREHhGteKCYG9kt0qpwYoJ+ydaKI\ncVoa9d8G1cf76WDqvv/etI3TPkRRjHvTNqLzTLPqKCjf3mv7LS3MHncyd5OA7PutKNi/2yg7qFnO\nzx1RQUzKdM+f+XRt3MZsRE+cdKaxLW8CABZfvTBt2+5sNpD8dmey1C9OiaIcSHwyg2LeOVXM0Mzm\nd7mH1olH3hGtvM/RtH5j4s9NFS7HCmWrjwfiP5myjc9Hyavm35YOsOcB+6sMRYzTw85fOgcAWH3c\n7bN4xWoAwCmbcMb15ccvvN8VvM9M0rsuA19yq+FvRct03OIM/t7fW8Ts7Gyqv53DoPO4/GAK+OFU\n3LZQ+7xsBLAKwPGE/TiAa7ghDMMP1W2sSYz0wEXzuDSLOjNomRLB44i9WDL3rygX28aMXHLWtIiP\nXa7uwcoX57XZRrtlvWux8hUGDil51aJkch1Alz2Qg0SV427jfhmU57GODHNRXW3ex/mTArKXSz0n\nKxfZwiTb8a1v7cehQ4ews/OyYgPGjbujP47+IWD/aJ6XkR64KDoO+niMSa9SIDx78dJsGknEAmnP\nTExKVpjRtR4aof2YOECagmJfutzzImZq9oOvh6bJD5m6KBt82wrs77Y/TRuKiTXU+fDfkx6M5g6Y\n2IfZgltNnauD+YNb+aM9Z2AleQWlNnjwMpNatu3SBEFMZvwAK5cQKOBeHapP7Itry3pm+H03Q17S\nPIGE5DnZX0nu23n08oUkgHwKWB78ZZh7peptC6UkxQshCS4I54dsk8xGIhVcQIIcAKcE2/uY7Smz\nXBNa02I/8qrcusPFMT9nJp9P/xbzSvxW5JU4dnTC1XfnatMn1gb1K9Zns+TXtwn2n3vGSR9/8OP/\nLwAX8A4Ah3E9AOD9+CtrowB88nZw8ID9+fG1Ubl59+BZGo9ki1+Da3fTmWgCfnH1ams7n/Z509VN\nXp83mMflyOJVAID1l7lJ/NlLuJKHwZ5s8RVfWe1OYdAel6w26+GkqWVzwr4ZGbIqXYEG5ysUCoVC\noVAoFCOCMAx/CeAJAB8kWxAEgfn/+8Pqlw/U46JQlEQ6cLdODpH8Mk14LZqor86Mry8tpQx9pSgP\nR1H5JtFkZvqu5vyxVJ2tucUQkBbNJbnFWkPV8+XrzSxLASt7HTZ53xW12xZ9rGveI0W30KUUAd7o\nqMclCIK3IXpqkxrYlUEQ/G0Ar4dh+DKAPwTw1SAInoCTQx4H8NUB9Lgx6MBF0RiaeciwQYClb/Wd\nzWYMZ7sQReQIa5+oQKQTz8sT9YzTuGYo/qSge7wvScRoYb6KRAcqn7dhPtTbazutVlSkbuRFr4n9\njsLA0+R0saINWaDfPEFtSecTofZkipWE8jQkqT55UB3OJ3OcmH15fpi9vWjJs35bOpZQ7162L+Vx\n4fQtuifFc8/6zumanvCnXsnlfCllvlTNQX+c17//ysdr5beZvPaSZXMofhLyKLa399i6WfJr9NPC\nPt+JFld/ynFGj79rEwBg9ilHZbp8xzMAgHHG49yEKO8JzyT/46PvTbdxn1lucNQzPGZussOsHDGr\n1jGbySq/6SaXx+UoIhraGUb3+hi+a6pwPLizJkv9PFhgv2X/pG8moowBwHFE54BywQDAy6sjatpG\ndrwnx6OZiPG/7R5sFNA/xwL77blcwxq8yCzvg4hlMzhZnrgBwPcAhObvD4z9AIA7wjD8z0EQbATw\nO4goYocB3BKG4S+G0Vlf6MBFoTCIKTm12a7OQNZCWY9HWUnlqsgSYSgum7BVUifLR1Uxi66CroEi\ngYukh6QpD0jbs8SSXHNbH4A+nplhiIYolie48EJywkdRD2EY/jcUhISEYfinAP60nR41Ax24KDqC\nkh+SPLiaZC85jeUWs6TgYC5HSbPBPJhf6gfN+sUC9s0+C7y/5gMiFtgszzD6zqI3+cJvoq6mM4b7\nlitWWpPO8/5YffGBjTTjmw4ut5Bmfq2sLwD0ED7pMxAQAtiLvHu5kO4XSfrYSX9b2HuHlaPrepKV\ne7BvV50Xy9WbOg4+6+0L60HNOx7EvDnhVwA+o583cK0WnC/vn0a2FyHebp/Ze7Xb9x2o53t/0h6S\npu5x2RPVs+3klbO/M5cZpuc7Zabnme4fMt6NrexmMt6LdbtY4m+Twf744iZr2j4WPdjP3+HcIWNY\nBABsTinEAqsYF2hiIvJQzGC7tZ2diDwfL73AlGRJ8pgLzGw1fX7E9fnyT0Wenpeevtbabtn2KLJA\nXiCOo7jUrpNEMXltAOAMomB7HsRPnpljrBydg/MZF4m8ORcsnba2VauWYtsAROHegPutAOdpWRB+\nb2FSZlkOds+ifapY2+11CBqcr1AoFAqFQqFQKDoP9bgohoYyVJqVhDaoYW3naSiLQQTsZ+9bTTyh\nVs6NO3K2LUNqoDTLPzShgFS7e8RtTeWSagtFSVy7dg9z+FDoAMTjoBSKlYKOBuevVIz0wGXfvn1Y\nv349du/ejd27dxfvoBggBCqNlHSM8j1wmhcF+97QQwrTZnkds9mA/b6zEZXsYFHwqHnx7mVtPSjU\n5x2cL2VyV/jDR/uf05rKBQlzao/9eBfyhcRs4seZ1K4woLLUKVbfgt/Hqzf1jAXHJ6lL0kCxmJpk\njmNB2JeLG8wIH+b2Hi8QFrC0tXyqX1lk0amyz3NaLKI470SaxlgHEu0qv3yzdByffb2eaduFekiN\njgeuU+z8PzXLPtv2anTRX3rTi9a0RMHq8+4Fsnk8on5RIDsHUaMA4Bo8m9r+XvwIQDxbPeUuuYrR\npIg2tm6LC2q/Zjyq78jWq6xt9VjU3vwn3b6Lhsb1m9vctUL94nS07Ya3fDp2giJsxfN2fUk4TqKP\n8eMg2wVwFDAK2D/Ngu6p3NIqVy/V03+95xqhdDCXOVOW0ELRdTQ1NYWpqSnMztbOEK9YYRjpgcsD\nDzyAHTt2DLsbihGCbwZonyDiMrOxg0hW2YbXpClUlSxuUuq4SQxSMrspBMG9mcICbYgD5B1TUab2\nsm3U8e50RfK8yTZ0IkZRFsnriyaUDx06hJ07RzNDvELGSA9cFN1CZmA0z7RNNj4jTTN3PNdrMpDz\nYbZtmvZj9VIc5D2sD/f30+VotvpxZiPEMoLvN5Kz/fT2tfsHrp5SNyi5K6g1W0wfzYkZP0n2ukwm\nc+e1EdoCgAfzB5kOB9Iz02KQetmPUSFwnkMUpchuK+6VEQQP8gQrYl4Ys53fT/a3SXsyYufFzs7v\nR/gkCiGf7/p01LgHzu++akPYoqtIXf9SPu5b2PqNZtk742wbTAZ3UgB28etYvzWq8NfwPWtba5Qo\nFsedjPAqw6vhngjyInBp4U0mKJ9LAVM5LodMAekb8Ia19Ywr6Oj4palysycvsraxNdGxLU5faG2b\nPx61+xxcYP9NJgcgFwpYJfCDVjOPUbLPR5hizXvwEwDASesWceC2RSO/zGWY6Xzw+r6HX4vKf8kd\nhz0d7lQx7EFZcYplA6WKtQoNzlcoFAqFQqFQKBSdh3pcFJ1CV6k5VZCXL8R3tnY5n48ynp4syk0b\nctFZbWXnp2hOSKLcOerLdoF+6Hvd5JUTxQ1iXsXBIb9f0TavRKPLFEnaTNvHWEQL8xW+WGn5ghT1\nsFzEJkrjLIBfDqHNEYUOXBRDQ+GDK5Yvw+CIsd3u+dAjihjX0b/bLO9nHwNEEePS+USpmeYVGgrM\nZTyPjNAXS5E5UEAXykP+R0HZ/ChNf/yUefGk6UctUNmkvAEAqgdIH7DL/Hwv+ZSIcvk1shC1ER+0\neA6oYiISJfe1YP3cSueix2hcOflHmDgAINDCpL4k9imGJIYgUPNi/Rjuh1Td+3TQ/c/vnzC45Xm1\niOq3hdnombzXma7f9kMA8TwlixMRZYkoXTxo/BKTOGQdCy4nWtNxmz0eWECULZ7nHLnKBLPzgHza\nzvelrPISTetlvD1VbiNc/pgf4b0AgA9OfNfabG6Vj7t6iML2drxsbXScnKJG52A1zqTKSeIBvNyL\n6AEALqBEN2wffk7pOEgwgO97EaPVWdGAx9xx2N/0CLNZKmn+dT3s+0+xfKADF8XQ0IWg7TbQ9Id5\n0Wxs1RnaJmbDhj377dO+mKXeUzTB1dHP327qG2QsU17w+7CQmomXJh+S+5Q8913GcpQ09veuKBQK\nxfChAxdFx8BmSMmTwWfuPmeWbzAbxT3ewGykFjltlhvYNqucyWYJpWBCklDmM9Q0cxiz9dL7Ut+l\nWSYuA2pnkmWZV/ch0YzXpO0Pp/rtSfKzDcN+/Kdn+uPB2HKfIrDfzzMbdJ4Ur7c3RhAe4LB95n1i\n9xN5SOLtJfvKvYbUXtqrVHxtUv+F2XkmWCHTkA7YckmI8uk5EtJN3QODCrr3FaQY5ICiyPuTpnT2\n3T/k0ebe63vMknlcLv1K9CDmmdw/iMgzwTO5k6eDAue5J4BkfHkgOQ+2T5Y7xV4EVI7vS33hAfFS\nOfKQcBlh8tY8jW3WRh6U/3ro71jbVTt+CiDu5Vhr2j3Djo3kkLknhQLnuSgAtds3XpEsnDT1cI8L\neaJ4cD55hGgb4H6DHtOiPjpvfiOeaoA8LoI0ehNS4J3FEtoPltfgfIVCoVAoFAqFQqHoLtTjomgF\no0ILGxS6TtdoWkSgStb7phEdUzN5PrLQ9Ex6WfGAWm2xwGsfieJBwR5DVs4YujZzufYFcsyxbcPP\nk5K3v8++hVRHb/GQ4d+niu6jar6jZQOVQ24VOnBRDBHCy+5W9mAjt/PtbDsF/dlM2nBULU4fI+oX\n5Q24jW27gtrqORtt/zorR/kF9rJy5LW/jNnuNMtPsH2lbMH0YXUkvakOJaq5zNhNfHyU1+rP76sQ\nCF+yrqJBs/2Ik/L1cBDFb6bgw7cgCDV335yBkixoUDSw2pPu04wQuC5kMc8974WxKwcSbWXvmxz0\niDQlNijJjBtauFfIX9PuB3WbH2bNCVw0nF/D5sRyprHb3gQAXHKx4+S+H38JIJ4z5XzzNfZ+/JW1\nERWKqFUbWAA70bjOZ19xRLfahqet7Se4HkA8+J0C+jndi3Ki8HwvRBHjgfjUHt+X+jfG8qpQPZM7\nHrG2FwVK17jJPcMpYERX41QxqQ3q17MsBwyt83NAQgavMVoY1f0Go9AtmPPNz9X3FicBAFeM9a1t\n7s9MPV9MHQ58n2kKRRXowEUxFEgzw0HQL0yONyooK2eb9+GRN5NbqOZUA4MKSq7rvUt/5HV/trgJ\n7493WxU8KcFHarRX8tjaPBd58L+vuL3P9ulVa5fF8uSJPwzSY9R1D7BC0SrU49IqdOCiaAVZs8Wp\noN+D7IVI3hfJQ8EHOLvMkmVUtp4WkkPm8ZpUH5fmJG8J9+6QZ4bPKFFgM5+Rn2Z9Idh8F3lSyQxi\nwD6HJO/a9Ad3Oe9Gcl+H+h9GTQ50imem82VyLWbSH6r2gz0mMWx+F57zRPLAsfaz+gtkD2LTfd7D\ntvViZZ0HIt0eAHdsguclDsGTQvcip2rZ481pC4D3NZx7/rID8GPnZyG7fPq339+oZHf0W/Vr1VFU\nf7nyPb+C97B66TnIn1/S9fIlszzsTGvXRSMs7gHYhp8BiEv20nbuUSAvwwlsiuriP6QBlyqm+rj0\n8QSOAYh7SMgbwr015L3g3gbCZibRTOV4MD31kwsAjAl9uQbPxergfTmM96Ta42IDJB7AzxmJAfA2\n6Dh5OfLq/Ff8urVdKkgfk1AAeVkA52k5Ms+VcgQIohhB0P2JIcXywkgPXPbt24f169dj9+7d2L17\n97C7o1AoFAqFQjHymJqawtTUFGZnZ4fdFUXHMNIDlwceeAA7duwYdjdGAkotWN5IzhYPRJa4BiQK\nThmqWtnr05a/tZ5naFD3RZP1DtJT0CTaEgBZac+y5fL7KkYLNKF86NAh7Ny5c9jdyYdSxVrFSA9c\nFMND+qNCyNNA9Jt7es72MbO8T6j0B4Ltthzbw8z2kFmygFJLN+P0MQIPzp82ywI6S4w6lESMDiec\nC1t3ebd72ZwRVdCcQEC1tursKycN7DNbL7N8jNqYxAJvr5fa7DuwcgOx7KbiKI7/yKTGzdxbcH5z\n6GixOJcewm+X6XO+OEUq6ep4s9dW0TVVNqu9fD/0avXBlquQ1LT8PbMnraxGtLFHWV13meU6Z6Ln\n5qZP/dyaKEs9D7qn4HNO8zprKFM9Q2ECHI2qZxJwcSoW5SRZZDlWCDwInihTPOie2ueB6UQR4+XO\nsnUCZbOfYP0kXMUe5n3DN34WVzNbz/Q9TVu7hAkV8DwvBBIU4LliqA88OJ8oasex2dqISrYdM9ZG\n53KBHSPPoUOgc3TJ+Elrm5szwfmTrODB1K5omkasUOjARTEUrHh5xA5hEEG6yd+vbenYPOR9XBZm\nCReyuNeXJ85ub1hoYpY9dV5qep9y605uy5A+LlWHwbCv0aJ4m7ztvqIAVaCeGEUdrDTPZC7OAvjl\nENocUejARdEKigNdBdlWCvy8v8/K9aIFD6yXgvf/qVlOmeUVbBt5Wh4X9uNyyCTHfI9QjrdJfeaB\nrPdLtn60lDwpC302Iyt5BWjWqrpsch3EM8h38YXUgMqU+DEs15sesEmesPw+Nf/BnN1XOYjfV4a5\nl7KJ10DK+5Q4PlFO2rVbyquxkPYMZT1jmvy4bzJgvw34XWPSb9CPDDz4/kaz5M/SD4cAgLENzntw\n1cWRd4U8JIDzLmxlD07yAFyPn1gbBaRzbwMFpJPnY4l9tpAnZRX7iqMgdO7Jofq4Z4YC6y9iwe+S\n3PC88TZwWWLq+wy2Wxt5OXig+48WfzU67rHnkQT3HEleHfII8W0UvD/PstqfMF4Vfmwk68y9OiTr\nzOWQ6RwdWbzK2hbmomNbfMsdx+qJqL4TR50Hx3rZ8rzOBl2atFEsf5w37A4oFAqFQqFQKBQKRRHU\n46IYKpSO4JDMz1Dl3HRtFrhJSmBTlK1B1Vd+vzz54uL6JVpbcZvlyvtKMw8Dri9pj0Ez9ZcP9h82\nBU2CmMgzIx7P95pSKMrAJ9+YK9u9e6gQS2g/WF6D8xWKYaCAqkL5THjOFopd5HLyk2b5ZWZ7yyyJ\n1sAD8T8t1EEMhmlmIyrZZczGKWoWFLTKTLcKNnuM+9O2Qs5+9keuDwaVFyXP1oVBlBSEnmWLowfA\nL7g8OwdM8/kLLJWHPjDX7rfB2rLIgExlS19D5YLP43RHz31m5L6kkZ8HJwoa7yMPwxKkaGJfX6GA\nxvqU9+y5ha3TM3TSma66Msq7cnzeUYiIDsapWpS7hFOXrsazAICNLCCdtk+86XKmnL4wokUdNUHj\nRKECgJOGvsXrIAoWUcwAR+OaYxQ0Ke8K5UzhVCxJRID24TbqH6eKbR6LjoPnbCG61aYJdxwkCsD7\n8j38WqxPgMs5w4P4ibbWQ9/aDuN6APHzTefoBAvYp36tHnPUuNlXo5fcO7c5Ch/h6oln7fpjcx+K\nVqTrZ0GeoFEomoAOXBSKDiJv5jPlmWl5lnRZzoh5IP4x3EDMTKr+vGBxaju/XVsH+1hoxvuTX6aN\n3zk/XqhqXf4xLk0fY5P3ia+nTqHoMqR7b0W8Q1QOuVXowEXROmQ1J2PjXhDyuFzHbOTBuITZKEMz\n33faLK81Sy6LTN6VDcxG+3KPCnlceCZ78v7cJZR7ldlIypnPGufNbHLqBu2ztpeSPi0zSFkRLwSG\nrODtKsfpv49fALvk0fD9QPahX6W8OiY4vehc1Dk38kdGL2XjXqn8gPm+0Jp0Tg8I5ygpqRrfbxDX\netPnbliQj6Nn16yM9SvydgsSKXnLmWi2f+t4WiGFZ5/nXgMCBeKP8ezu81FgPXlZAGDD65Ft6eLI\nQ8G9EhRYf4YFppMXhHtDzhjvCs90T33iXgkC95AsmGPk9VFQ/jY8bW1copjQf70HAOhd3Hd92TgW\nax8Anp2PpIzHx90D/9Tr0XG+/WJ3HjeZc3YCm1w5cz74eaFym5h3ioLyuRzyBYK88qZtkYw19zq9\n9ELUPy7CYD1vC+lnUBD4Pw+TWGnvLUXz0OB8hUKhUCgUCoVC0Xmox0UxNGggaDEK847k5LRIJe1L\nzHgPIlCyyHvgW1/5rPdp+kzWDF86B00/t/4iJNsvtx+89q1OB+vb9aLzUq4+2fuUX3e5c1RHVCDL\nPujZ3C55WsS+0LOCe6cvSxdTKKqiSwIerUGpYq1CBy6KboDczTewD4sjvWj5IVaOYhJ5LgGid3E2\nAnnNKWCf0yCI5sXLU/6W25ntBrO8pRfravj7QPBuZqB9OH2NMghLFLCiwEW7j/BxGFMDOmDrcx/h\n6V2aRhma1SA4+FVyaZSn8FDm8L5n+TS9KdbPhgbpTVDBmty/HNLnqIwoAN/Xp9/ZognZ9TaJQQti\nNAZ6NvIBzC6z/KgzXbotysvCKWAEHjBPQeKcWkXbicIEOIrYxjdnrW2V+fhb/T8WXOWGmrbh/DkA\nwMkL3YOW6FZzsSzzUb083wvleYkH7C+aci5PCq1TNnrAZZ/n9CwKjj+KS5ktyirP86Rcf3HEY352\n8WprGx+Lju34oqtv8a2IPjZ3yh3H+o1vpPr3V3h/rP3oOM6Y/rmge8rpwulj1xgxBJ57huqen3cP\nqLlHTP+vD61t3RbXnm3jmZQJ7n2WfHftVwqYojHowEWhKIngjiG1+5GcbUOe6a0TWF3eq1P+WPPl\nkOU+N+pJYbFOw/6tONJeucH2LX1Oy4kg5CunZZctUy/VXdVWth/NSIX3zVrzohIKRRNoSxRjKDgL\n4JdDaHNEoQMXxfDAPQ9EYeCZ64nO8B1mo8k27i1Jx31i7PY3AQCL6y6MDK+ky4DHk1Lg6Tpme8Ms\nf8ps5N3h+362Hy15IP52s84D++83y4fZg3pa6BdILYyVm6SV4g+TrI+pdmSUpVn18vWVaTd9vPtj\ndRR/bNI5lT6o3fHY3yORA8PrvGZIBqeD0NPb6lEvkkHt5bxPaQ9Pz+wrnat8yeU2PuCLZKCbasen\nD90BOwd07ZI3GwDuNkvuxZ6MFuRlAeJB9ATyqrwff2VtlGGee2YoSHyDfagCm1+PPC0Bp7xQ4P8s\nUlgyz34ufUzgge4kkSwF3fN9+0aAYC2cd0c6RqpvLeZT27inhzw8W9nLgQf5E479hTnR72JtfS4S\nDVj/JafwQp6Zk8yVT2IEi0yMgMQDnjt6jbX96sSPAMR/A/qtuKDAj/De6Di4p+e2qA8bx9y5evn1\n6DguudjZ5p4hz5J033ftHlCsJOjARdEKmlCCGiXkxa6sZFSRsU3X0Wd19JrrU87v0SUvyiBRJS6n\nqXs9eY6bTiraFNqSkB7JWAKFoovQBJStQgcuiqGhUCr1hl603M5s5LW4gdkmzZJ5VRa/bjwtp4Ty\nJF98D7M9ZJaPMdsupEFtcc8QzTjfzj5UHuxHS/K8AMCXzDKhHBrOZ3xwxWJXTH0Dihupi7YHotnt\nSR/U+bPu7tynJXZlCeI0f1tGecleOblnr3C/5uBLjeOetQzRiJx9OcpeO36Utvq5TnwTrRbFXLV1\nb0QxWcIGnsCXZOG57DvFKkw6E0nicg/Ee4zuPJce3mhjPSasrYfIS7OOeTzIG8E9HqfXR/VceMIl\nP8T/EPq/JlpQ/AuPnVm1FK2fWuViOS7AXKoK8gKtZsfjZJMd54Y8JMfY8ZBHhieWPGLoAM/iGlYu\n8shwaeGTizzw0WCriR35rqsPd0aL2ZMXWdPShuicXcDi4w4ffQ8AYNfEX1obxepcOuHicuh4ufeH\nklJKiTR5YsnnXoheuLOn2EWyIerzsbdYn+070O95qJOViqagcsgKhUKhUCgUCoWi8xhpj8u+ffuw\nfv167N69G7t37x52d0YOSnWIkKc4JVFzmpB3zZVKBWziyzLUrS7OqEnXGNmKZuJ9r882pIqzzm0V\niWuf/lTbv36Q/CBQJEDQxes2D1l0vWGfZ4WC0MQ9NjU1hampKczOCgFPXYPKIbeKkR64PPDAA9ix\nY8ewuzESKH5wGXfzdlaOKF1EuwKAP+9Fyx7blW22oJhSCqy/j22bNMsNzEbrW4RynD5GVDUeoL3X\n9Pk2Vu5Bs+QSo9NCPwnb4+cnfDL58C+nFrScPsaaDdhnwfTiwKCf3sWivIJYFqS8OV1DcVb7/H18\nylZR4aqC7IFdu9m6hyUvLcZhTZqlJEzyPhYYvi6i/4xtedOaSB53cvx71kZ0rw+wQPyzRk6Xy+5O\n4FiqOZIK5jSlC48uUiUO9EXyWtp2vuny2BnX98XVUd95ID71hbfFM8gTiGLFcb7Zh8s2UxD/PNwM\nkyRAQEH0FMgOuKz3zx9liXPWmHZ3Ocrd1VdG2ez7r/fcsRmJ5KVxJ4d888SjAIBn4eSViX7HZZOf\nfyGiq2240okWnDZCAvzYTjz9DgDAma2uLzjsAvBGAAAgAElEQVRl+IZvORMOG9sWRhW7xSxnmntu\nctCE8qFDh7Bz586BtKFYnhjpgYtC0VVUn8WvH9xepe6m0XRbdeSa4/X0a/eletvNegp8jiXvmqmi\nehbLf5TTlzzPUV5Qfvl8Pdl18vrKwrc+eWDXT9h62e1oEl+FYvhQj0ur0IGLoiMwH5RcPnhvz6z0\nnO3zZnmLM4HiGRNB7wBcckjJk8IxY5Y8lvKwsC+tX8b6RPj7fbdO0sjT8SJRID4rx4L3wyejZf5H\ndnN5GrKCz5Nl4n1Kb+sC8oLak54rnySOkhhC1gd6VS9CEa3LL5i/fh0RWsj/QV7F7fvtte6PrMR2\nBRCU4Lp03VaBk+dmRknxzgR841Vmo+fXU27mfN2uyBsyPu7kfm/C9wEAq5lX4u14PmqKyQKTF+YK\n5vYm7weX7CUvDAXTx8AViIkVxGXpEwH7bzt7zv1zsUk2eb77lNmwKq2PTyIDcfniVal+njTJI3nA\nPokRcI8GeVcOz7/H2raORy+gRRbATt4XSiYJALOvmESR5NkA8Nw3zIieJX286spItph7ep7HVQCA\nzcxrQoICJw69wx2w8ZacvtId7/NPXxf1fat7ya3rRb/97GfZS+5Gs7zWmfBNs+RCOV80y7U9Sy0m\nLPd7rNPoTwE/nwIWlwGFbkDQ4HyFQqFQKBQKhaLr6O0GPvAtYMcDw+7J0KAeF4WiRQR35GxrgB6W\nZe/aDFgZ2tNgaGPppGlZtJsimplEf5LaKF1vh38/oDn6XX7dzaMpyp30+/jnGqpDZTPnmye8VSg6\ngK4/swaGswB+OYQ2RxQ6cFF0BlEegr4zUFD+F3v5Oz5sljwIlShi02bJA+c/YZYPMRtRxX7KbB8z\nS848oED9aWabzOkb30be+L09ZyMtfJ5ZXaJ9JLK1KwYMQ3/IEkiwH6oZMRtUvvzLO5sS1fSHQJxm\nlp+LJR3PwvuXR99ig5oZfi6TdD3Xl/yPH3mA4EP/axtVRSdq5e25na1fm1jCBeBfdfHzqV0pgB5w\ndK+eQAE7n5HrKTCcB8ePGyrZZhYQT/lT5letdfW9LaKhBY715L5I3hJsb4sWZ9azTUtEG3NfcYur\nImrXqZj6SgROuyL62AKz0T483wsd7zHGIx43uV1+ffy71va9xUkA8Xwqx17oRX169ULXCRKdmWYd\nM3nG1m1JZ6tfnHb7XvrxSHVmG562th//xQeiFU4JNKlsjt+wyZrWb40KzD7O87OY5V62L11DdzEb\n0cc+wWyxd1IPCkVb0IGLojPwmaVWVEPTM9h5wdC+3pNBoMn6m6hLUjarXk9+4sY6bbUtpVs1Ziqv\nn0UB8XWOsc5McnkvDHsGqldFsQzQdQXFgeMc2g+WP1dcZKVCBy6KoUGcZd3rbNYb8bgz2UmvG5EG\nlx4m+WOaEPsm2yZlsOeeFgLNOPF6KeD1YJ8Ze9FC+sjggf10HLzdBWlWW7CNm7oXigd2ZYLFq8wK\nN/WRm9f2wGbMyZu1kDyG/YIt3hfp5eyCzPMC/GXIogBSH4Y3mC9zfciDkR77z28A0aw8toT0+axS\nlywIUU4uuhL29qIlfy7SM4qp7lLg9eZx5/kgiWAu47sBUeD4cywLPHlauCdlg3E9833JQ8Eldp3t\neMq29Rhzi5OT5G3sOMjhwIPzabspv4pRZJbMF8zp1TzoPvuzZpwJCxzFBIC4d4WOkYLgo/pWxcrz\nfX6E91rb5rHoHFDmeQC4/MooI/1L32BuLzq2e1jHjMz+3ORGa7Ly1Cxgn849/12uujl6eT1/6DpX\n31PRgntX1t9gXDKHXTHblzlmo2uJX1/Efri152zXmfX7+6zgnnoeQ4XCAzpwUSgUCoVCoVAoquAs\n2o850RgXhaI9jGwAXwHk/BT9aCWDMtIE/WW5/QaDSGroR0Haw2x9s5aOeynf5uA8Kllt+M6K1rlG\nmhabqIo6gfB+9LU++4+uB6W8KhQKxSCgAxdFJyDmJiBIlIgrmG2XWfIM95NmSXSvz7NtPzDLR5mN\n54UhkJedBz1ScCIfSFD7B9kH0hf2p/tEfZ8p+pASPnoWpA/Q7I/mLGpXE3z/OhSZNgZJudnEC6h5\nyXqkHDD+WeZ7vl0uAAX555+7Ou35XxfZgfiDoBMWtVNUrikFsaau27L0SPc8ZPc90Xa+0HM2E2S9\n7pMuwH7u1AWxJQD8o4n/CMBlUefrH4QLNCdIGec3MLWSeUTB9jzHCdGZeNA72UKWeN0G5XOaEoEH\n5xNVzMQQnM/yuiyZQP2L5l1Oi+PjUUD6GMtBQ5nueXA+0cbmheD8Myy3C1HPeLkTiNrg4gVPL77T\n9N3lZ3npa4Yi9i52PGvMcprZKCCeMekW11yAJOi3+mvc5No4al6GfVaQzimjSM+uMS+0L7Fy9N7j\n71PC19n63l56O6OIKT1M0SZ04KJQrEC0HWyd1W4bA5XKM/sFWce74jFw9fZj/2d9LAzrt28TVa+z\nqh4kfq1Qsr0mPGZiMlopka5C0WGMPItiCe1Tt9oWA+gQdOCi6BZ4gPSt5gHIZY5pnQdvkkfmNsFG\nM1kPs20U4M+D7ikolHt3aDaKe1yoPhYEa4UA+Mz+Z/vG1nM20WtCiMvLZs7sxyhj+1MZi7PQRbnY\nqijyJmX9H5U3K/y3Whudx9hARvDMuP976foqIq0Mlr2tqTZ8y0oDuyaC2H2ljMsOToZxviKk1d4a\nG8DTdbid7U/PpdvDVPG5x1xw966bvwMAuIh5SCiInnsjyINyAXN9bDTSyFz6mAL7T7OH7xVmmp/X\nR54MLq88tmSkj5m3BEwh2II8LWcEm/G8nLyUP/zjfcvqJ4F7hmidyybT+glstjbytPCAePLg8CD+\n2SNbqBIHel/NIA2ehV7wOq2/LO3tWjSeoEU41xXJLx/7BHObTArtfc4s+XsvFlhvsLcXLfm7+EGh\nPromCxkECkWz0IGLQqFQKBQKhUJRBZqAslXowEXRCYy8DnwCvucjGEdKxncQ3pRhUMDqYlD0hSwq\n1rByoRTFp+T1K3dfKRFqDdTNKt+2mESsHw2ci/hxafC+YjQw8jQyRePQgYuideQ/vJwOvKWq8A9z\nck/vYba9xsZ18YnSRWwBido1yWxEB+OZpwlMHt8G9FOALODoW7y+V3p2lXJ9BOP70325gVb2I/yK\nKSckErQUooV784UMhoy2X0x1KDiN9DUzL0yEsm3kB2/37Horg6SmzlESJQYBVWljRfWVRuz3TdZR\nJy8Mo5nN7Enb6Fx9le3SN8tTjFdo6FQ33vw9a6Ks9jsZ/5WoUDyrPVGrKJ9LtB7xndayvCerDR1s\nNaOF0b4TcNniiYJ1htGZVp0108N8lvj1eN8BuOc1p5QluPwb///27j5Yjuq88/jvsWSBJEC8KAgw\nzl472E4g2KBL4mT9gqoo7MUhWWdjx9w4KRbsVFyonES1XlLZchW7LuLasPi17FRStWskp5KbJa5k\ni8IB1smCWTtrjO9FhgBmI4e7KIAEQnBBlhDo6uwf3Wf6zEzP3J6e6e4zM99PlWquzvTLmemZnj59\nnuecvUFcVbq959+wvlV08koS0vXUmrOzsjTMKwwLO6DNbc9J7QMP9FvXh4+FIWqtmen/Ipi869+m\nMW9LwagE/vfntGAn/ncgCEteviecBCyx8s7kki0ccEEvpNsOf1f8b9bNOaHXIf/bFa57S5+JUMPv\nwUP+/EBjBPWi4YLG9LoDadfWX5cqDdPAGNUFaumk5Bp7EYpenI7qIrboncBR3jEc956r0KjqXsVn\nbBTDhI9y/XE4zsCoTMMAIW2Oq/5k+eM17y8iNFwQifQu4zXBD/yRpfSP4M6PH3EnvHvkbyjeHGzu\njzueC4c7zutV8UM//nPOc+fm/P3emazM98LckdMzFI4Q5F/PQ2FPSrDOV/xryh9ytuvip28C+eiH\nph23i69+wzbnvic9ek26BZ/HwuvUq8hQz/3+P6r9r1bWVP2KKjJ8ceHv1/qcc1tY1hr4Iyjz55ss\nz12brkxuy5+z7ulWWZZgn/UeeE8HM75fmGaJH2iNUJIl2Id8T4IfxljKEsLDpPsNOiKpffhg3yMT\nzlK/8cX0KitMuvfC3hV/RZK3nHcw+/Pom5LH/enwxJK0do3vBcreH59EHw4icEK6k3BoaN+rckZr\ntBbpe5qVlL3WcN2n/2eQEH9eOlhC2HuxM+0NCYfF9x0pzwdl/ncq/K3xgg6mQ1/b3L4NSfp8zjp5\nSff+9+mKnM9h3uABrWHYh795M26/HYgbDRcAAACgDIZDrhUNF6ABecn3Re7c9kran8QEyGGTscf5\nPckLKRuk52xUc9A0+b5VUZd+AxrEHEYJNKHfIDHVzVc1vudt1IOGC6LR8+Isb+bzf84JpwiT8313\nvQ/VuiR4LpwR2NuWPuYl4ofykh59/cJ6tsa2DxN3d3WX9U3uHs3IQ8Oc/Ov84Sga3jbSpPpVtpv3\nw90+8eNg4UKjfD9HNf/JoPsZpaq2PXAYV866xeV/TzsnCA3nXGoNthGGrfrE7HA+Kh8S9F+zohPe\n45Pks3iqNent3jA8y896f74eaZX5ULIwmd6HSoWJ5uvSbZ+Wk6yeN2eLn6dFkl5Zk4SNnXEwjHFK\nH8Mrjpdzyp5JH388KOu4k30siM46vGF9Wo8sjMsPDhDO2eJf754gjmt/MFdLpyXNtP7279lKUNHd\nT12c/BHO8XVuelBvDMo+qu4yH9K8PSfH8xPZflthy2FImX/t3wjK/GfkjqWgMC/c+OrWcl2DvrTN\nN9axfPp3rwlve6HRgarQcEHtYhlOdtwk70/5xkyZC9omEtibUDahetDP7Go5HWV6VVarZ97npuhF\nyCC9XkV6iapK6G9kiORBl71m/L4XmEzZZ7P478kw57px/E0YyDHVHyrGPC5AM/qFbLTKWkn6UutE\nG96p9L0qYVmYICm1Jz36Hpe27c4kD88FRQ+lz++Zycru6ahHx3ayO1np8213snKGOz3iX2+Ri8+O\ndSfYKH7o+iZWt9397te7M1Nwb+UaBv1M/I99DaoYpKJz++29cgW/n1fMJI/hecrfnT/LtYpOOis5\nIZ3xlSwh3ifMh7O7z6QJ9hdpd6vM9zj4oXvDdcPk82PpcmHvii8Le2F84nqYsO97a05dk627+dlD\nfiOZE9PHZ4Iyf/URJuf7UYMP5SyXPh7emA0EsO5o0jO07oSszNfzSPC6fe/KmqBSfkjox/SWVlmr\nBynozfIDD4TDIW/anHSDLL8z6LX5Vtp98c6g7mGPjLc9p9EQ/k54vpcm/F27MH18OCgLowRay6Wf\n+7ZZ7Xf1jmpo+y3M06cHRz0GmymJ8x5WMzENFzM7V9KfSjpTyRymNzrnvtZsrQAAADCxjim56qx7\nn1NqYhouSg7j7zjnHjSzLZIWzOzrzrkjq62IuBSdNT5GZeuef6dqNDkusYfgDZcgvRSsO1PpvvL2\nudp+iu6j3zFa7fjVGZIxyJwuecvaBnXlc40m6X4p3dZM175Huf3u8uHCN4E6xThpMTCoiWm4OOf2\nKe2Ydc7tN7MDkk6X9GSjFUOX/hcSOYnr24OnL08fwwR7PwZ+3pwpPiQjtC19vCB47ssd60n5swr7\nkLN7gnX7dbO3XaRd3XocPJSoe50yF2ejnMl9mO3Gqkxidr/jUmT7g+RrFMmFaWowhl5hWa06D3jR\nVOR9SPa1VHp7wxzvvuGb4eAP29LH8DziE/CD+TjW/eSLyaonZXGMm9clIV2zrZNcNk9KmHS/OQ39\nCpPufVJ5OO/K2jT0KwwB25LGb4XhUT7ZPUxw9+FoPjxLktanoVUra3MuJcIiH5n2clC2nD6eqG7h\nuhvbnzrlmWwggOfPXp+zavLawrlq/Dw3T+nsVpkPJQtf41PpnDd7g9EBfKL+S4ez+V4O7d7cu+6h\nk9LH8Nhfkn42blnKyralj2Gosve9nL8/FpTd7v8IPod7sgFjfFhs9v3rP5hEK2G/TfK57/wOhyG3\nyTYm43dgYExAWauJabiEzGxW0mucczRaIhZ7T0CV7H3pH20jwayyzpDDA4fbGHY7k6DokNTdjYX2\nH/5kO/1zG+p636uYtb3qu7S96rza+WGUwyMPsu1x7hEGRqnXb1JMw6pj8kTRcDGzd0n695JmJZ0t\n6f3Ouds6ltmuZMDbsyR9X9LHnXP352zrdCVXER+put4Yre6LlfRkF84CfNdM8hgm21/S8ShJ+9Ll\n7si5MPEzB4fDHfs7Yu+dCfaVPoYJjv5OVoHhi52bab97dWG67bzZkXPv3C8F/+u+MB60NyTWhuJw\nd/lnSu2r/b1N7yYWfn/CY9Hr7mXx1zTMTNSlEsOHkd7BLTXMcOvu7GgT5kcxEEI5/nOzlBXlfcd9\nsvapQZnvaQkS8c8/PelBeSqY6d73coTD/fok8bB3xfd8hLPA+0TzcBhfP5t8OJTysaDHwfO9FqcG\nCfvPpT0YZ67NMuw3/Cjp/Vj7YtYL0oq9z4vBD684fG9F9+7bl9vU/tTR4P8rOSv7wQhODjL8/XKv\ntLL/pb16fdvykrRfZ0qSLgm6Of7PP21L6xu8Rr/pbCyErDck7Enxn4cwGsB/NsKEfH8D6w+Csk+m\nj+HnZnu63O3Bcq19dQyP/mD7062eF+t//up7Psr93QPq9ZqmK5DaqOQUcJ0k1/mkmX1I0meU/OJd\nrKThcpeZbe5Ybp2kv5b0aefcfVVXGgAAAFNsRdmQyHX9qzs0LSJR9Lg45+6UdKckmeVGWO6Q9CfO\nua+my3xM0i9IulbSTcFyuyT9nXPuz6utMaoQa49AWXWFlJSdP2MUoWcxG1V4Vp2fy0EHG4hFv3C5\nzuMwqu9Ftp1qepraj3t+zxrJ+YiVvVUdwyGXn4trtXBRQpBRpygaLv2Y2WuVhJB92pc555yZ/a2k\nnw+We4ekD0p60Mx+WUnPzW845x4WxkorDOatvmQme9KfiPcEJ8dW93VwAeG76H2SbJgc6WckDkPL\nfDd/GJbmE/vDfbW2E5T5+V5yQ4iubluuf0hS5wm//YJslDOgT1ojcVB5jYJy74+fG2G1/VWTMN/+\nOiq6YOgKD7mhVHJ8vt5hev2S/Yvss5ILqHCwDx+GemFQ5sOAwrk8UuuuerH19yv7TpEk/cQbswT7\nPYeTk8tFGx7oWjcMiToznX/Eh5FJ2VwjbwjKWnOsBOFePlH/OW3uKgvDqPy6YRiZT+g/5YksZOpH\n5/igjSxTeO2yuvnItDB8zCfd/yinLFzO/90nEd4PWCBlgwyEIXd+oIKQf1/CJH4/yMFt+sVWmZ9L\nZ8uG/a2yH34ynTzlSmX8fCs+TFnKn2PlnvQx/F7536lw0Bn/WbojpwEdDOrQqn6YLxl+Jju0fa98\ng6RkCFivXLSpa7wwAWWtom+4SNqsJAp2f0f5fimbOco5920N+Hp27NihTZvaA2jn5uY0NzdXrqYY\nidZFSZ+T77gaZCjdXuWx56yMQtk7eMO8J3W8n1UmreZP4roUlM10LL/U9v9BenjGJUF9tVGQgGnS\n1UOYN/Fl27J+uXoaIvPz85qfn28rW17Oawljmo1Dw6Uyn/vc57R169amqzG1Vr1ru6e7KDcs45p0\nO+Esxf6O1J7sMUtOTPf1UNCj4RMbr5nJyvzdr7C3JqhTV7LjhTm9MGHjq9UzEw6puqR+ijZSOi+A\nV7sgnpY7YqN4nUW2Mar3M8bwsGKvv2MgipxZtXv9v5zu3shSAwb0G6o5vFjzd6TvCM4/fpCPvLvq\nYW/u59PHYAjbXzz/LyVlCeKSNLsh6fZ9Qae1ynyC/duVpWweUFtqpyTpLfq/6bpZJvcZae9B2Nvw\nTDqD/JnBfcBDOT0zeT0UZz2bXkCelJVtfCbtaTkaLOiHPM6LwQ97V/zVxwk5y23MWS7nasX3CIW9\nK753akvwGh/QxZKkU/V8q8yvcyRIzvdl/2/xJ1tl62aSnrIf7g4OtD++/1HdZSEf79E690utz27e\n5yvsNfU9LVeEZel2blkljPGhvJsYOd+P1lD+BYfoD4ZX7tz+KOTdOF5cXNTs7OzI9oHxNw4NlwNK\nToFbOsq3qP1SFQAAAKjPMUmvNrDPKRV9w8U596qZLUi6TNJtUiuB/zJJX2yybhgvow5vyXJwSqzb\nY06Q3sv1Lxtsn4led8rKhDNNU3Jmkfd/tXkNhtl2r30U1S/RtmwoW7/vVrG5cYobZUhfr/fCbKlv\nGA0wLgb9vqz2O5k3KEbe93nSfwfQnCgaLma2UUlAjg82eKOZvU3SQefcXkmflbQzbcB8V8koYxsk\n7Rxmvz7HhbyW5uV1U+cmDvpwrDCMzCfW54Rx6SvptvJOxmFol0+EvCXnJP9Q3oABOdvJCwd4KGf5\nNmHIS7KdQS7qJvXHoezramrW+Bj2kz8z/EyfNTpH4xqkXvkDUXTn0VSXN1TofWyFwngzPZZbfQQx\nSe3J+d5pwd8+Eumns9ipTf8jKbxk3UKr7D69XVIWziVl861crCw5388x8nwQAubDuMJwrsNKZpB/\nvfa2ynzo15rg1qwPnzrjYDbHiU5XulwW2+VDzmYOPt0q+9EpSSL+xhdzpuwO0xB86FcY7uWnnAlT\nSv064VQseQn4HXeW172c/X1oQxLmFs7F4sPr/JwsSZWS4xEOSpA3AEEr5CzYxyv3JAMp6OeCeLgT\n0xf5eFCxL6eP24KyvHnEfIjYke6bBO0N6fRzeE9YlhdmttT+XJ99dC2not+jYjfaRsnnu4xFjstx\n1T88cc7XcFpE0XBREh16t5KRwJySOVuk5Bt2rXPu1nTOlk8pCRHbLem9zrlnh9kpOS7xGVVCYGs7\nV4zmIrG1vQurv7iNMfF5mKTyaZxFuY6hpusazaeJQSCKvH/lemuWJnLQDyA2w/a++BvK5LigUxQN\nF+fcN7XKZJjOuT+S9Ef11AhRONJ94mudDMNGTZp4X/hCxoeAhD0kvmekLREyZ3u+V6ftTm53l7m/\nez3cRV/BhMmCiv54DDOT+zRY7bUO06AoHppV/nOVN4P9oPsfdNlE3t3a7iT+/qFlS2lJztwtuTcV\n+s8SrvOSGcbNckZauipYbl+67WAY2nU3J0nbr/z6KVnhl5wk6c3nPNYq8sMWh7PV+2T7i9qmXk+E\nCfa+ByXsSfE9I+H2fO/LuqDM97SsBD/zvndh7+lndq3reyAk6fUvJj0tFiTTb1xOb/GGd5bz4uzX\n5jx3Qk6Z/zvvKiTsrfG9MGkvyEvnrAs2sSbdfPa6w9fh+ffsuWDoY5/EvxBk1fv34qSLDrTKDi2l\nvTTnBaMIbE8fv5wVtX4T7sifV6ir1z6nNz5MfG8NdnFkKfhuXN1d9r6ZdMEb5P6mc4t5Q4qv1muS\n93vWuY180zDiJZoXRcMFAAAAGDsrqj9Zvu7QtIjQcEHtqkjgGyZRfpSqutPUfz6O6QvFGlZT71mV\nAySE69WRLFtHIu4w+ygachljaCYmz6jDjVv5MNty9tFnOPJe9cr7fvXt4QQaQsMFUSl8cZKXsJ87\n70L/8ey7u8KXurcbjImfzekyk5WtkoA/aPf5uM7lUcW646iO15t/kVFVeEZ7aEmvme6LrttusMEp\nWuExGzrmLeoKFU33uz5vuaX+VT4vp+ys7qJX/iINEfvdoPDEZAb3cKZ7/3eY/B7Oet/anpIQqDDp\n3oc9hdvLm2PFh0ytDfbh5ycJl1/bCjPLyo6m+91y+Jmu7bbx87eEU0H7kK5wHhcfXhbOz+LvRufd\nJT49+NuHhQXbc2lCv+VcrWzQEUnt8+G8ku44DLk7mpY9Hpy3T1ByrML3xz9/6AfBXDl+PsSbgx1/\nIn3cHpR9Od32kfY6ds0x9FB34yJf3ncj2UdbEn9eSHOO4ueM4gn4vc5103bOp8elXlPdcGFUselS\nbGjh0Y+aMsxwlDE2YpDpdWyb/uHu95nLa7j3/4y2fyeKfJ77xdOPZDjvkgN39BsKGmhSoZ6PyIbo\nrnKAkLEaVQy1muqGC6OKNWMUd+/b7poGSfbZhX7/pMLeM23vKtgzM5qQn1H0wjR9kTyOmnrP6hgg\nYfRhcMOEiexadf+9nw8bPR11yB3mOGf58O53XmPHD298T1B2VfdiuipJuted1ira9NFk/uOVY9nP\n6BkbkqTuMOne39H3w/RKWTL5GcqSwH1vSDhEcmu7wXJ5PSl+6ONwaN/T0rL1wZuw/mjHtOdqT+hv\n1cX3muT1pORdR4Z3m/1QwnlXF+FwyL6nJdyH73EJkvOfOz3p6jn5cDKE8wtrsp4UP+Sxf/2S9IjO\nlyQdCpL0/XDSYS+MF/bCPH0wHQ75VJctMJce8y8FK+XNdO8/k4VDwfJ/azJ9bqIdyWnEd3wnyt70\nygYCCLdXbBCNURqrUcWamAxyiieg7DuSFwAAAADEYKp7XBCfUd8t7jsz9iDbGWEiMkNFYhoVDV+T\n6EXEdOgfvlzNZI+9fvuq/I3j+4xRouGCsTRwN/j6G1pj5Gcn7v6Jw/2ThEd3Iu7cFnkt4yPGH+Ty\noVn5y5bJ4xlFHcLvQds8KznP91w+nGxyj7r5pPswzObGdJ0wZOzGNFzoE1nR8u3Jym/+Nw+2ynwy\nfThfiA8LC0OyTkrDvF7Qaa0yH0rWmr1d0vqcsvP1iKQs4Tx5acmIAjPBVO5+nTD0bMMJh9vqKYXz\nuGTzo6xsSC4NTl7JwtFOeeYV/4IyPmH/0Cpl56jLsXQ7K8FVyJo0/OXoCVkwyH5tkSQd2JC8pz8M\nRk/w72n4/vhwsOeUJdgvpeFgS3pDq+yRw+d31ak14MLt3fVtS4L34WB3JfMASZL55Pw97fOxSO2f\n99bNtLZZ7f3nOwyJ3NX9/Tvit5U3P0unIt/zqwsOttF7EA0oSZS3VZca/T6nFA0XAAAAIHavzCf/\njk/voAXmnFt9qQljZlslLbz73e9mVDEAAICIhKOK3XvvvZI065xbbLpeIX8tqQ0L0pqaB3paWZQO\nz0oRvi9Vm+qGy8LCAqOKAQAARCgYVTg1mPIAAA4CSURBVCy6C3QaLs1gVDEAAAAA0SPHBQAAAChj\nRVLdwUvHa95fROhxAQAAABA9elwAAACAMo6p/uGQpy89vYUeFwAAAADRm+oelx07djAcMgAAQETC\n4ZCBEMMhMxwyAABAdMZiOGQtSFbztaRblBTn+1I1QsUAAAAARG+qQ8UAAACAoUxf8FJj6HEBAAAA\nED0aLgAAAACiR8MFAAAAQPRouAAAAACI3lQn5zOPCwAAQFyYxwW9MI8L87gAAABEZ2zmcVHd15LM\n4wIAAAAA0aLhAgAAACB6NFwAAAAARG+qk/MBAACA8o5JerWBfU4nelwAAAAARI8eFwAAAKCUY6q/\nB4QeFwAAAACIFj0uAAAAQCnkuNRpqhsuO3bs0KZNmzQ3N6e5ubmmqwMAADD15ufnNT8/r+Xl5aar\ngsiYc67pOtTOz3a6sLCgrVvrnu0UAAAAq1lcXNTsbJwzxPtrSembki6qee+7JV0qRfi+VG2qe1wA\nAACA8lZUf+jWSs37iwfJ+QAAAACiR48LAAAAUArJ+XWixwUAAABA9Gi4AAAAAIgeoWIAAABAKYSK\n1YkeFwAAAADRo8cFAAAAKIXhkOtEjwsAAACA6NFwAQAAABA9QsUAAACAUkjOr9NUN1x27NihTZs2\naW5uTnNzc01XBwAAYOrNz89rfn5ey8vLTVcFkTHnXNN1qJ2ZbZW0sLCwoK1btzZdHQAAAHRYXFzU\n7OysJM065xabrk/IX0tKX5N0fs17f0TSB6QI35eqkeMCAAAAIHpTHSoGAAAAlEeOS53ocQEAAAAQ\nPXpcAAAAgOjdkf471HRFGkPDBQAAACjlmOoL3bo8/feopF+vaZ9xIVQMAAAAQPTocQEAAABKITm/\nTvS4AAAAAIgeDRcAAAAA0SNUDAAAAChlRfWHbq3UvL940OMCAAAAIHr0uAAAAAClkJxfJ3pcAAAA\nAESPhgsAAACA6BEqBgAAAJRCcn6d6HEBAAAAEL2p7nHZsWOHNm3apLm5Oc3NzTVdHQAAgKk3Pz+v\n+fl5LS8vN12VAkjOr5M555quQ+3MbKukhYWFBW3durXp6gAAAKDD4uKiZmdnJWnWObfYdH1C/lpS\n+qKk82re+x5Jvy1F+L5Ubap7XAAAAIDyyHGpEzkuAAAAAKJHwwUAAABA9AgVAwAAAEohOb9O9LgA\nAAAAiB49LgAAAEAp9LjUiR4XAAAAANGj4QIAAAAgeoSKAQAAAKUcU/2hW4SKAQAAAEC06HEBAAAA\nSiE5v070uAAAAACIHj0uAAAAQCkrqr8HZKXm/cWDHhcAAAAA0aPhAgAAACB6hIoBAAAApZCcXyd6\nXAAAAABEjx4XAAAAoBSS8+tEjwsAAACA6NFwAQAAABA9QsUAAACAUkjOrxM9LgAAAACiN1ENFzP7\nKzM7aGa3Nl0XAAAATDqfnF/nv/qS883sSjP7gZk9ZmYfqW3HPUxUw0XS5yX9RtOVQHzm5+ebrgJq\nxPGeLhzv6cLxBuphZmskfUbSNkmzkn7PzE5rsk4T1XBxzt0r6VDT9UB8+KGbLhzv6cLxni4cb6A2\nPyvpH5xz+5xzhyR9XdJ7mqwQyfkAAABAKROdnH+OpCeD/z8p6XV17TxPFD0uZvYuM7vNzJ40s+Nm\n9ks5y2w3s8fN7IiZfcfMfqaJulatqjtJw2x30HWLLr/acv2eL/tcbDjexZ7neFe3XY53dTjexZ7n\neFe3XY739JrUa+soGi6SNkraLek6Sa7zSTP7kJIYuxskXSzp+5LuMrPNdVayDpz4ij0/KSc+jnex\n5zne1W2X410djnex5zne1W2X412HuhPz/b9VjeLa+ilJ5wb/f11a1pgoQsWcc3dKulOSzMxyFtkh\n6U+cc19Nl/mYpF+QdK2kmzqWtfRfPydK0qOPPjpErauxvLysxcXFqLY76LpFl19tuX7PD/pcVe/r\nsDjexZ7neFe3XY53dTjexZ7neFe33XE/3sF12omrVqoxB6Lc54iurb8r6QIzO1vSS5L+laRPDVv7\nYZhzXY2wRpnZcUnvd87dlv7/tZIOS/oVX5aW75S0yTn3y0HZNyS9VUkr86CkDzrn7svZx69J+rMq\nXwcAAABG4sPOuT9vuhIhM/txSY9K2tBQFY5KerNz7onVFhzy2vpKJT0zJukPnXP/baSvYkBR9Lis\nYrOkNZL2d5Tvl/SWsMA5d3nBbd4l6cOSliS9PGT9AAAAMHonSppRct0WFefcE2b2U0quU5twoEij\npYdBrq1vl3R7yf2M3Dg0XEbOOfecpKha7gAAAOjy901XoJe04VC28YASYknO7+eAkilCt3SUb5G0\nr/7qAAAAAGNrbK+to2+4OOdelbQg6TJfliYZXaaIW+EAAABAbMb52jqKUDEz2yjpPGWjgb3RzN4m\n6aBzbq+kz0raaWYLSkY42KEkGWpnA9UFAAAAojWp19ZRjCpmZpdKulvd40zvcs5dmy5znaTrlXRj\n7Zb0cefc92qtKAAAABC5Sb22jqLhAgAAAAD9RJ/j0hQzu9LMfmBmj5nZR5quD6plZn9lZgfN7Nam\n64Jqmdm5Zna3mT1sZrvN7ANN1wnVMbNNZna/mS2a2YNm9tGm64Rqmdl6M1sys84JqjGB0mO928we\nMLO/a7o+qBY9LjnMbI2kRyRdKumQpEVJb3fOPd9oxVAZM3u3pJMlXe2c+9Wm64PqmNlZks50zj1o\nZluUJCi+yTl3pOGqoQJpwukJzrmXzWy9pIclzXI+n1xmdqOkn5C01zl3fdP1QbXM7J8kXcA5fDrQ\n45LvZyX9g3Nun3PukKSvS3pPw3VChZxz9ypppGLCpd/rB9O/9ysZFvL0ZmuFqriEn2h4ffpovZbH\neDOz85RMoHdH03VBbUxcz04NDnS+cyQ9Gfz/SUmva6guACpiZrOSXuOce3LVhTG20nCx3Uomivsv\nzrmDTdcJlblZ0u+Lxuk0cZLuNbP7zOzXmq4MqjVxDRcze5eZ3WZmT5rZcTP7pZxltpvZ42Z2xMy+\nY2Y/00RdMTyO93QZ5fE2s9Ml7ZL0m1XXG+WM6ng755adcxdJeoOkD5vZj9VRfxQ3imOdrvOYc26P\nL6qj7ihnhOfzdzjnZiX9a0n/wcx+uvLKozET13CRtFHJkG7XqXsIOJnZhyR9RtINki6W9H1Jd5nZ\n5mCxpySdG/z/dWkZ4jOK443xMZLjbWbrJP21pE875+6rutIobaTfb+fcs+ky76qqwihtFMf65yRd\nleY83Czpo2b2yaorjtJG8v12zj2dPu6T9DeStlZbbTRpopPzzey4pPc7524Lyr4j6T7n3O+k/zdJ\neyV90Tl3U1rmk/O3SXpJ0v2S/iXJnHEre7yDZbdJ2u6c+2B9tUZZwxxvM5uX9Khz7lM1VxslDXE+\nP1PSYefcITPbJOlbkq5yzj1c+4tAIcOey9Pnr1aSsE1y/hgY4vu9QUm47yEzO0nSPZJ+yzm3UPdr\nQD0mscelJzN7raRZSa3h8lzScvtbST8flK1I+ndKvgCLkm6m0TJ+ih7vdNlvSPrvkq4wsyfM7O11\n1hXDK3q8zewdkj4o6f2WDJ+5aGYX1F1fDGeA7/e/kPS/zewBSd+U9AUaLeNlkHM5JsMAx3yLpG+l\n3++/l7STRstkW9t0BWq2WdIaSfs7yvcrGYWkxTl3u6Tba6oXqjHI8b68rkqhMoWOt3Pu25q+c98k\nKnq871cSZoLxVfhc7jnndlVdKVSq6Pf7cUkX1VgvNGyqelwAAAAAjKdpa7gckLSipGsxtEXSvvqr\ng4pxvKcLx3u6cLynB8d6+nDMkWuqGi7OuVeVzJJ9mS9Lk70uUxIbiQnC8Z4uHO/pwvGeHhzr6cMx\nRy8TF+dtZhslnads/PY3mtnbJB10zu2V9FlJO81sQdJ3Je2QtEHSzgaqiyFxvKcLx3u6cLynB8d6\n+nDMUcbEDYdsZpdKulvdY4Lvcs5dmy5znaTrlXQ57pb0cefc92qtKEaC4z1dON7TheM9PTjW04dj\njjImruECAAAAYPJMVY4LAAAAgPFEwwUAAABA9Gi4AAAAAIgeDRcAAAAA0aPhAgAAACB6NFwAAAAA\nRI+GCwAAAIDo0XABAAAAED0aLgAAAACiR8MFAAAAQPRouAAAAACIHg0XAJhQZvabZna3mS2b2XEz\nO6XpOgEAUBYNFwCYXOsl3SHpDyS5husCAMBQaLgAQOQscb2Z/aOZvWxmS2b2+2b2WjP7kpk9ZWZH\nzOxxM/s9v55z7ovOuZsk3ddg9QEAGIm1TVcAALCq/yzpI5J+V9K3JZ0p6XxJvy3pSkkfkLRX0uvT\nfwAATBxzjugBAIiVmZ0k6VlJ1znnbul47guSznfOXb7KNi6V9L8kneace7GyygIAUCFCxQAgbj8l\naZ2ShkennZIuNrPHzOwLZta3AQMAwDij4QIAcTvS6wnn3AOSZiR9UtKJkm41s1trqhcAALWi4QIA\ncftHSS9LuizvSefcIefcXzrnfkvShyT9ipmdWmcFAQCoA8n5ABAx59xRM/tDSTeZ2atKkvN/TNIF\nkjZJelrSA0qGO/5VSfuccy9IkpltkXSWpDdJMklvNbOXJD3hnHu+9hcDAMAQaLgAQOScc59KGy3/\nSdI5ShorfyzpgKTrJZ0naUXS/ZLeF6z6MUk3KGnUOEnfTMuvkfTVWioPAMCIMKoYAAAAgOiR4wIA\nAAAgejRcAAAAAESPhgsAAACA6NFwAQAAABA9Gi4AAAAAokfDBQAAAED0aLgAAAAAiB4NFwAAAADR\no+ECAAAAIHo0XAAAAABEj4YLAAAAgOj9fwO1QaIE9+cUAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f74691bcc50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(10, 8))\n",
+    "mh.plot(log_scale=True)\n",
+    "plt.xscale('log')\n",
+    "plt.yscale('log')"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "xenon1t",
+   "language": "python",
+   "name": "xenon1t"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/hax/cuts.py
+++ b/hax/cuts.py
@@ -47,7 +47,7 @@ def selection(d, bools, desc=UNNAMED_DESCRIPTION,
     n_before = n_now = len(d)
 
     # The last part of the function has two entry points, so we need to call this instead of return:
-    def get_retval():
+    def get_return_value():
         if return_passthrough_info:
             return d, n_before, n_now
         return d
@@ -63,7 +63,7 @@ def selection(d, bools, desc=UNNAMED_DESCRIPTION,
                           "Showing historical passthrough info." % desc)
                 if not quiet:
                     print(message(c['selection_desc'], c['n_before'], c['n_after']))
-                return get_retval()
+                return get_return_value()
 
     # Actually do the cut
     d = d[bools]
@@ -74,13 +74,12 @@ def selection(d, bools, desc=UNNAMED_DESCRIPTION,
 
     CUT_HISTORY[id(d)] = prev_cuts + [dict(selection_desc=desc, n_before=n_before, n_after=n_now)]
 
-    return get_retval()
+    return get_return_value()
 
 
 def cut(d, bools, **kwargs):
     """Same as do_selection, with bools inverted. That is, specify which rows you do NOT want to select."""
     return selection(d, True ^ bools, **kwargs)
-
 
 def notnan(d, axis, **kwargs):
     """Require that d[axis] is not NaN. See selection for options and return value."""
@@ -147,3 +146,19 @@ def range_cuts(*args, **kwargs):
     """Do cuts based on one or more (axis, bounds) tuples. See range_selections docstring."""
     kwargs['_invert'] = True
     range_selections(*args, **kwargs)
+
+
+##
+# pandas.DataFrame.eval selections
+##
+
+def eval_selection(d, eval_string, **kwargs):
+    """Apply a selection specified by a pandas.DataFrame.eval string that returns the boolean array.
+    If no description is provided, the eval string itself is used as the description.
+    """
+    kwargs.setdefault('desc', eval_string)
+    return selection(d, d.eval(eval_string), **kwargs)
+
+def eval_cut(d, eval_string, **kwargs):
+    kwargs['_invert'] = True
+    return eval_selection(d, eval_string, **kwargs)

--- a/hax/cuts.py
+++ b/hax/cuts.py
@@ -10,15 +10,20 @@ import logging
 log = logging.getLogger('hax.cuts')
 
 # Dictionary mapping id of DataFrame objects to list of cut information applied to it.
-# Weakrefs might have been nice here... but as DataFrames are mutable, they can't be hashed
+# Weakrefs would have been really nice here... but as DataFrames are mutable, they can't be hashed,
 # which means we can't place them in a lookup-by-hash container.
 CUT_HISTORY = dict()
 UNNAMED_DESCRIPTION = 'Unnamed'
 
+##
+# Cut history tracking
+##
 
 def history(d):
     """Return pandas dataframe describing cuts history on dataframe."""
-    d_id = id(d)
+    return _history_by_id(id(d))
+
+def _history_by_id(d_id):
     if d_id not in CUT_HISTORY:
         raise ValueError("Cut history for this data not available.")
     hist = pd.DataFrame(CUT_HISTORY[d_id], columns=['selection_desc', 'n_before', 'n_after'])
@@ -27,6 +32,34 @@ def history(d):
     hist['cumulative_fraction_left'] = hist.n_after / hist.iloc[0].n_before
     return hist
 
+def _merge_histories(*ids):
+    # Collect all the history dataframes
+    histories = []
+    for x in ids:
+        q = _history_by_id(x)
+        q['id'] = x
+        histories.append(x)
+    histories = pd.concat(histories)
+
+    new_history = []
+    for desc, x in histories.groupby('desc'):
+        new_history.append(dict(
+            n_before=x.n_before.sum(),
+            selection_desc=desc,
+            n_after=x.n_after.sum())
+
+    return new_history
+
+    histories = [ ]
+    histories
+    for x in history()
+    for x in ids:
+        new_history
+    return merge_histories()
+
+##
+# Cut helper functions
+##
 
 def selection(d, bools, desc=UNNAMED_DESCRIPTION,
               return_passthrough_info=False, quiet=None, _invert=False, force_repeat=False):

--- a/hax/cuts.py
+++ b/hax/cuts.py
@@ -40,7 +40,7 @@ def record_combined_histories(d, partial_histories, quiet=False):
                  n_before=sum([q[cut_i]['n_before'] for q in partial_histories]),
                  n_after=sum([q[cut_i]['n_after'] for q in partial_histories]))
         if not quiet:
-            print(passthrough_message(q['selection_desc'], q['n_before'], q['n_now']))
+            print(passthrough_message(q))
         new_history.append(q)
     CUT_HISTORY[id(d)] = new_history
 
@@ -48,8 +48,11 @@ def record_combined_histories(d, partial_histories, quiet=False):
 # Cut helper functions
 ##
 
-def passthrough_message(desc, n_before, n_now):
-    return "%s selection: %d rows removed (%0.2f%% passed)" % (desc, n_before - n_now, n_now / n_before * 100)
+def passthrough_message(passthrough_dict):
+    desc = passthrough_dict['selection_desc']
+    n_before = passthrough_dict['n_before']
+    n_after = passthrough_dict['n_after']
+    return "%s selection: %d rows removed (%0.2f%% passed)" % (desc, n_before - n_after, n_after / n_before * 100)
 
 def selection(d, bools, desc=UNNAMED_DESCRIPTION,
               return_passthrough_info=False, quiet=None, _invert=False, force_repeat=False):
@@ -82,17 +85,17 @@ def selection(d, bools, desc=UNNAMED_DESCRIPTION,
                 log.debug("%s selection already performed on this data; cut skipped. Use force_repeat=True to repeat. "
                           "Showing historical passthrough info." % desc)
                 if not quiet:
-                    print(passthrough_message(c['selection_desc'], c['n_before'], c['n_after']))
+                    print(passthrough_message(c))
                 return get_return_value()
 
     # Actually do the cut
     d = d[bools]
     n_now = len(d)
 
+    passthrough_dict = dict(selection_desc=desc, n_before=n_before, n_after=n_now)
     if not quiet:
         print(passthrough_message(desc, n_before, n_now))
-
-    CUT_HISTORY[id(d)] = prev_cuts + [dict(selection_desc=desc, n_before=n_before, n_after=n_now)]
+    CUT_HISTORY[id(d)] = prev_cuts + [passthrough_dict]
 
     return get_return_value()
 

--- a/hax/cuts.py
+++ b/hax/cuts.py
@@ -94,7 +94,7 @@ def selection(d, bools, desc=UNNAMED_DESCRIPTION,
 
     passthrough_dict = dict(selection_desc=desc, n_before=n_before, n_after=n_now)
     if not quiet:
-        print(passthrough_message(desc, n_before, n_now))
+        print(passthrough_message(passthrough_dict))
     CUT_HISTORY[id(d)] = prev_cuts + [passthrough_dict]
 
     return get_return_value()

--- a/hax/cuts.py
+++ b/hax/cuts.py
@@ -34,6 +34,7 @@ def history(d):
 
 
 def record_combined_histories(d, partial_histories, quiet=False):
+    """Record history for dataframe d by combining list of dictionaries partial_histories"""
     global CUT_HISTORY
     new_history = []
     # Loop over cuts
@@ -51,6 +52,7 @@ def record_combined_histories(d, partial_histories, quiet=False):
 ##
 
 def passthrough_message(passthrough_dict):
+    """Prints passthrough info given dictionary with selection_desc, n_before, n_after"""
     desc = passthrough_dict['selection_desc']
     n_before = passthrough_dict['n_before']
     n_after = passthrough_dict['n_after']
@@ -68,7 +70,7 @@ def selection(d, bools, desc=UNNAMED_DESCRIPTION,
      - force_repeat: do the selection even if a cut with an identical description has already been performed.
     """
     if quiet is None:
-        quiet = hax.config['print_passthrough_info']
+        quiet = not hax.config['print_passthrough_info']
 
     # The last part of the function has two entry points, so we need to call this instead of return:
     def get_return_value():

--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -7,6 +7,11 @@
 # Experiment to analyze data for: XENON100 (pax reprocessed) or XENON1T
 experiment = 'XENON1T'
 
+
+##
+# Minitree options
+##
+
 # Branches which are activated by default in loop_over_dataset(s) and every mini-tree maker
 basic_branches = ['event_number', 'start_time', 'stop_time',
                   's1s', 's2s',
@@ -25,6 +30,17 @@ tqdm_on = True
 # Print out selection/cut passthrough messages from hax.cuts by default?
 print_passthrough_info = True
 
+# Directories that will be searched for mini-trees, starting from the first.
+# The first (highest-priority) directory will be used for the creation of new minitrees.
+minitree_paths = ['.', hax_dir + '/minitrees']
+
+# Format of minitrees that will be used for saving new minitrees and that will be searched for first
+# Can be 'pklz' (for compressed pickles) or 'root'
+preferred_minitree_format = 'root'
+
+# Other minitree formats to check for. It's ok to re-list your preferred format here, it will be ignored.
+other_minitree_formats = ['root', 'pklz']
+
 
 ##
 # Processed data access options
@@ -33,10 +49,6 @@ print_passthrough_info = True
 # If 'latest', use only data processed with the latest available pax version for each dataset
 # If a version number (e.g. 4.10.2), use only data processed with that pax version.
 pax_version_policy = 'latest'
-
-# Directories that will be searched for mini-trees, in order.
-# The first (highest-priority dir) will be used for the creation of new minitrees.
-minitree_paths = ['.', hax_dir + '/minitrees']
 
 # Runs database url for XENON1T, password will be fetched from os.environ['MONGO_PASSWORD'] if possible
 runs_url = 'mongodb://pax:{password}@copslx50.fysik.su.se:27017/run'

--- a/hax/minitree_formats.py
+++ b/hax/minitree_formats.py
@@ -1,0 +1,158 @@
+import os
+import json
+import warnings
+
+import numpy as np
+import pandas as pd
+
+try:
+    import ROOT
+    import root_numpy
+except ImportError as e:
+    warnings.warn("Error importing ROOT-related libraries: %s. "
+                  "If you try to use ROOT-related functions, hax will crash!" % e)
+
+from hax.utils import save_pickles, load_pickles
+
+
+def get_format(path):
+    path, ext = os.path.splitext(path)
+    if ext not in MINITREE_FORMATS:
+        raise ValueError("Unknown minitree extension in filename %s" % path)
+    return MINITREE_FORMATS[ext](path)
+
+
+class MinitreeDataFormat():
+    def __init__(self, path, treemaker=None):
+        self.path = path
+        self.treemaker = treemaker
+
+    def load_metadata(self):
+        raise NotImplementedError
+
+
+class PickleFormat(MinitreeDataFormat):
+    def load_metadata(self):
+        return load_pickles(self.path, load_first=1)
+
+    def load_data(self):
+        return load_pickles(self.path)[1]
+
+    def save_data(self, metadata, data):
+        save_pickles(self.path, metadata, data)
+
+
+class ROOTFormat(MinitreeDataFormat):
+    def load_metadata(self):
+        minitree_f = ROOT.TFile(self.path)
+        minitree_metadata = json.loads(minitree_f.Get('metadata').GetTitle())
+        minitree_f.Close()
+        return minitree_metadata
+
+    def load_data(self):
+        pd.DataFrame.from_records(root_numpy.root2rec(self.path))
+
+    def save_data(self, metadata, data):
+        if self.treemaker.uses_arrays:
+            # Activate Joey's array saving code
+            dataframe_to_root(data, self.path, treename=self.treemaker.__name__, mode='recreate')
+
+        else:
+            # Check we really aren't using arrays, otherwise we'll crash with a very uninformative message
+            for branch_name in data.columns:
+                if is_array_field(data, branch_name):
+                    raise TypeError("Column %s is an array field, and you want to save to root. Either "
+                                    "(1) use MultipleRowExtractor-based minitrees; or "
+                                    "(2) add a uses_arrays=True attribute to the %s class; or "
+                                    "(3) use pickle as your minitree format." % (branch_name,
+                                                                                 self.treemaker.__class__.__name__))
+
+            root_numpy.array2root(data.to_records(), self.path,
+                                  treename=self.treemaker.__name__, mode='recreate')
+
+        # Add metadata as JSON in a TNamed in the same ROOT file
+        bla = ROOT.TNamed('metadata', json.dumps(metadata))
+        minitree_f = ROOT.TFile(self.path, 'UPDATE')
+        bla.Write()
+        minitree_f.Close()
+
+
+MINITREE_FORMATS = {'.root': ROOTFormat, '.pklz': PickleFormat}
+
+
+##
+# Utilities for saving array fields in pandas dataframes to ROOT files
+# This is not supported natively by root_numpy.
+##
+
+def is_array_field(test_dataframe, test_field):
+    """Tests if the column test_field in test_dataframe is an array field
+    :param test_dataframe: dataframe to test
+    :param test_field: column name to test
+    :return: True or False
+    """
+    if test_dataframe.empty:
+        raise ValueError("No data saved from dataset - DataFrame is empty")
+    test_value = test_dataframe[test_field][0]
+    return (hasattr(test_value, "__len__") and not isinstance(test_value, (str, bytes)))
+
+
+def dataframe_to_root(dataframe, root_filename, treename='tree', mode='recreate'):
+    branches = {}
+    branch_types = {}
+
+    single_value_keys = []
+    array_keys = []
+    array_root_file = ROOT.TFile(root_filename, mode)
+    datatree = ROOT.TTree(treename, "")
+
+    # setting up branches
+    for branch_name in dataframe.columns:
+        if is_array_field(dataframe, branch_name):
+            # This is an array field. Find or create its 'length branch',
+            # needed for saving the array to root (why exactly? Wouldn't a vector work?)
+            length_branch_name = branch_name + '_length'
+            if not length_branch_name in dataframe.columns:
+                dataframe[length_branch_name] = np.array([len(x) for x in dataframe[branch_name]], dtype=np.int64)
+                single_value_keys.append(length_branch_name)
+                branches[length_branch_name] = np.array([0])
+                branch_types[length_branch_name] = 'L'
+            max_length = dataframe[length_branch_name].max()
+            first_element = dataframe[branch_name][0][0]
+            array_keys.append(branch_name)
+
+        else:
+            # Ordinary scalar field
+            max_length = 1
+            first_element = dataframe[branch_name][0]
+            single_value_keys.append(branch_name)
+
+        # setting branch types
+        if isinstance(first_element, (int, np.integer)):
+            branch_type = 'L'
+            branches[branch_name] = np.zeros(max_length, dtype=np.int64)
+        elif isinstance(first_element, (float, np.float)):
+            branch_type = 'D'
+            branches[branch_name] = np.zeros(max_length, dtype=np.float64)
+        else:
+            raise TypeError('Branches must contain ints, floats, or arrays of ints or floats' )
+        branch_types[branch_name] = branch_type
+
+    # creating branches
+    for single_value_key in single_value_keys:
+        datatree.Branch(single_value_key, branches[single_value_key],
+                        "%s/%s" % (single_value_key, branch_types[single_value_key]))
+    for array_key in array_keys:
+        assert array_key + '_length' in dataframe.columns
+        datatree.Branch(array_key, branches[array_key],
+                        "%s[%s]/%s" % (array_key, array_key + "_length", branch_types[array_key]))
+
+    # filling tree
+    for event_index in range(len(dataframe.index)):
+        for single_value_key in single_value_keys:
+            branches[single_value_key][0] = dataframe[single_value_key][event_index]
+        for array_key in array_keys:
+            branches[array_key][:len(dataframe[array_key][event_index])] = dataframe[array_key][event_index]
+        datatree.Fill()
+    array_root_file.Write()
+    array_root_file.Close()

--- a/hax/minitree_formats.py
+++ b/hax/minitree_formats.py
@@ -15,15 +15,15 @@ except ImportError as e:
 from hax.utils import save_pickles, load_pickles
 
 
-def get_format(path):
+def get_format(path, treemaker=None):
     path, ext = os.path.splitext(path)
     if ext not in MINITREE_FORMATS:
         raise ValueError("Unknown minitree extension in filename %s" % path)
-    return MINITREE_FORMATS[ext](path)
+    return MINITREE_FORMATS[ext](path, treemaker)
 
 
 class MinitreeDataFormat():
-    def __init__(self, path, treemaker=None):
+    def __init__(self, path, treemaker):
         self.path = path
         self.treemaker = treemaker
 

--- a/hax/minitree_formats.py
+++ b/hax/minitree_formats.py
@@ -16,7 +16,7 @@ from hax.utils import save_pickles, load_pickles
 
 
 def get_format(path, treemaker=None):
-    path, ext = os.path.splitext(path)
+    _, ext = os.path.splitext(path)
     if ext not in MINITREE_FORMATS:
         raise ValueError("Unknown minitree extension in filename %s" % path)
     return MINITREE_FORMATS[ext](path, treemaker)
@@ -50,7 +50,7 @@ class ROOTFormat(MinitreeDataFormat):
         return minitree_metadata
 
     def load_data(self):
-        pd.DataFrame.from_records(root_numpy.root2rec(self.path))
+        return pd.DataFrame.from_records(root_numpy.root2rec(self.path))
 
     def save_data(self, metadata, data):
         if self.treemaker.uses_arrays:
@@ -66,7 +66,6 @@ class ROOTFormat(MinitreeDataFormat):
                                     "(2) add a uses_arrays=True attribute to the %s class; or "
                                     "(3) use pickle as your minitree format." % (branch_name,
                                                                                  self.treemaker.__class__.__name__))
-
             root_numpy.array2root(data.to_records(), self.path,
                                   treename=self.treemaker.__name__, mode='recreate')
 

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import dask
 import dask.multiprocessing
+import dask.dataframe
 
 import hax
 from hax import runs

--- a/hax/treemakers/peak_treemakers.py
+++ b/hax/treemakers/peak_treemakers.py
@@ -39,7 +39,6 @@ class PeakExtractor(MultipleRowExtractor):
             cut_string += obj + '.' + cut + ') & ('
         cut_string += obj + '.' + cut_list[-1] + ')'
         return cut_string
-    
 
     def extract_data(self, event):
         if event.event_number == self.stop_after:

--- a/hax/utils.py
+++ b/hax/utils.py
@@ -1,6 +1,9 @@
 import collections
 import os
 import platform
+import pickle
+import itertools
+import gzip
 
 
 def find_file_in_folders(filename, folders):
@@ -63,3 +66,30 @@ def flatten_dict(d, separator=':', _parent_key=''):
         else:
             items.append((new_key, v))
     return dict(items)
+
+
+def load_pickles(filename, load_first=None):
+    """Returns list of pickles stored in filename.
+    :param load_first: number of pickles to read. Otherwise reads until file is exhausted
+    """
+    if load_first is None:
+        counter = itertools.count()
+    else:
+        counter = range(load_first)
+    with gzip.open(filename, mode='rb') as infile:
+        result = []
+        for _ in counter:
+            try:
+                result.append(pickle.load(infile))
+            except EOFError:
+                if load_first is not None:
+                    raise
+    return result
+
+
+def save_pickles(filename, *args):
+    """Compresses and pickles any objects in filename.
+    The pickles are stacked: load them with load_pickles"""
+    with gzip.open(filename, 'wb') as outfile:
+        for thing in args:
+            pickle.dump(thing, outfile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ numpy
 pandas
 mock
 tqdm
+dask
 #pax
 #ROOT

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 pandas
 mock
 tqdm
-dask
+dask>=0.11.0
+multihist>=0.5.0
 #pax
 #ROOT


### PR DESCRIPTION
This includes several enhancements to prepare hax for large-scale analysis. 

Here is an [example notebook](https://github.com/XENON1T/hax/blob/outofcore/examples/Preselections%20and%20out-of-core%20computation.ipynb).

Parallel minitree loading
-------------------------
`minitrees.load` now has a `num_workers` option, which will spread the loading of several minitrees over multiple cores Each core gets separate runs, runs are not split over cores.

This is useful to create minitrees faster from the root files, and works well with the preselection feature (see below).

Please don't abuse this option to spam the jupyterhub with hundreds of minitree creation processes when people want to use it for analysis. If you need many minitrees, use a midway compute node / batch queue job, ask your friends to share their minitree folders -- or better yet, lobby the computing group to maintain a folder with pre-made standard minitrees!

The multiprocessing is done by the dask multiprocessing scheduler. If you have a remote machine with a [dask scheduler](http://dask.pydata.org/en/latest/scheduler-overview.html) setup you can try to use that by passing `dask_compute_kwargs=dict(get=your_scheduler)`. I think. I haven't tried this.


Preselections
-------------
Often you're interested in a small part of the data, e.g. the low-energy events. You can then use the preselection option:

    data = hax.minitrees.load(run_numbers, preselection='cs1 < 1000', num_workers=10)

This combines particularly well with parallel minitree loading, since the preselection can then be applied separately on each run, i.e. "out of core". Previously you had to first load in the full data -- potentially blowing up your RAM -- before you could apply a cut.

Note that 'cs1' is just a variable defined by the basic treemaker; you can use any other variable defined by a treemarker you're loading in. So if you have more complicated preselection cuts, use a treemaker to output a cut boolean (or p-value, or whatever you want to cut on) and use that in the preselection string. The preselection is evaluated for every run after merging the dataframes for different treemakers.

The cut history of your preselection is kept, as if you did a normal cut. (this required some strange magic for the parallel case)

Some finer details:
  * You can specify a string or a list of strings that can be parsed by pandas.eval. 
  * Passing a list of strings is the recommended way to pass multiple preselections (instead of using & to string conditions together). This way we can track the cut history separately.
  * If you need to refer to e.g. the local x variable, also pass `pandas_eval_kwargs=dict(local_dict=dict(x=x))`, then you can say `preselection = cs1 < @x` (but in this trivial case `preselection='cs1 < %s' % x` would also have worked).
  

Out-of-core computations
---------------------------
What if you want to e.g. make a cs1/cs2 spectrum of all events? You can't use preselections to make the data fit into RAM. You could write a for loop over datasets, adding to the histogram on each pass, but that's tedious, and you'd have to write your own parallelization code to get it fast. Instead, try the delayed option:

    data = hax.minitrees.load(run_numbers, delayed=True)

which outputs the data as a [dask dataframe](http://dask.pydata.org/en/latest/dataframe.html) instead of a pandas dataframe. You can still use the hax.cuts functions on this, much of the pandas functionality, and make histograms using multihist (not plt.hist or np.histogram). You can't make scatter plots -- unless you use something like [datashader](https://github.com/bokeh/datashader), or reduce the data down to a manageable size. 

If you like more info on dask, see e.g. [this talk](https://www.youtube.com/watch?v=PAGjm4BMKlk), or several longer talks on youtube.

Unforunately cut history is currently not kept when doing out-of-core computations. This will be a bit of a challenge to implement in a nice way. 

Minor changes
---------------
* The use_pickle and use_root options have been removed. Instead you can now set the following hax.init options:
  * `preferred_minitree_format`. Format of minitrees that will be used for saving new minitrees and that will be searched for first.
  * `other_minitree_formats`. A list of other minitree formats to check for. We'll only check for these if we can't find any in your preferred format.
* This means you can no longer directly convert between minitree formats at the moment. You can still re-make a minitree in another format of course. We might want to re-enable this feature in the future.
* The pickle backend now uses compression (gzip).
