### PR TITLE
Small changes / fixes

### DIFF
--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -133,3 +133,4 @@ minitree_paths = ['.', '/cfs/klemming/projects/xenon/common/PaxReprocessed_9/goo
 [rcc]
 cax_key = 'midway'
 raw_data_local_path = '/project/lgrandi/xenon1t/raw'
+minitree_paths = ['.', '/project/lgrandi/common_minitrees']

--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -37,6 +37,9 @@ minitree_paths = ['.', hax_dir + '/minitrees']
 # Cache newly made minitrees to disk. If False, will just make dataframes
 minitree_caching = True
 
+# Make minitrees if they don't exist. If False, will just load them from disk.
+make_minitrees = True
+
 # Format of minitrees that will be used for saving new minitrees and that will be searched for first
 # Can be 'pklz' (for compressed pickles) or 'root'
 preferred_minitree_format = 'root'

--- a/hax/minitree_formats.py
+++ b/hax/minitree_formats.py
@@ -5,8 +5,6 @@ import warnings
 import numpy as np
 import pandas as pd
 
-import hax
-
 try:
     import ROOT
     import root_numpy
@@ -46,7 +44,11 @@ class PickleFormat(MinitreeDataFormat):
 
 class ROOTFormat(MinitreeDataFormat):
     def load_metadata(self):
-        return hax.paxroot._get_metadata(self.path)
+        # This is NOT the same as paxroot.get_metadata, that's for pax ROOT files...
+        minitree_f = ROOT.TFile(self.path)
+        minitree_metadata = json.loads(minitree_f.Get('metadata').GetTitle())
+        minitree_f.Close()
+        return minitree_metadata
 
     def load_data(self):
         return pd.DataFrame.from_records(root_numpy.root2rec(self.path))

--- a/hax/minitree_formats.py
+++ b/hax/minitree_formats.py
@@ -5,6 +5,8 @@ import warnings
 import numpy as np
 import pandas as pd
 
+import hax
+
 try:
     import ROOT
     import root_numpy
@@ -44,10 +46,7 @@ class PickleFormat(MinitreeDataFormat):
 
 class ROOTFormat(MinitreeDataFormat):
     def load_metadata(self):
-        minitree_f = ROOT.TFile(self.path)
-        minitree_metadata = json.loads(minitree_f.Get('metadata').GetTitle())
-        minitree_f.Close()
-        return minitree_metadata
+        return hax.paxroot._get_metadata(self.path)
 
     def load_data(self):
         return pd.DataFrame.from_records(root_numpy.root2rec(self.path))

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -318,7 +318,7 @@ def load_single_dataset(run_id, treemakers, preselection, force_reload=False):
     for ps in preselection:
         result = cuts.eval_selection(result, ps, quiet=True)
 
-    return result, cuts.CUT_HISTORY.get(id(result), [])
+    return result, cuts._get_history(result)
 
 
 def load(datasets, treemakers=tuple(['Fundamentals', 'Basics']), preselection=None, force_reload=False,

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -360,7 +360,11 @@ def load(datasets, treemakers=tuple(['Fundamentals', 'Basics']), preselection=No
                                        num_workers=num_workers, **compute_options)
         result = mashedup_result[0]
         partial_histories = mashedup_result[1:]
-        cuts.record_combined_histories(result, partial_histories)
+        # Combine the histories of partial results.
+        # For unavailable minitrees, the histories will be empty: filter these empty histories out
+        partial_histories = [x for x in partial_histories if len(x)]
+        if len(partial_histories):
+            cuts.record_combined_histories(result, partial_histories)
 
         if 'index' in result.columns:
             # Clean up index, remove 'index' column

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -304,6 +304,8 @@ def load_single_dataset(run_id, treemakers, preselection, force_reload=False):
 
     # Merge mini-trees of all types by inner join
     # (propagating "cuts" applied by skipping rows in MultipleRowExtractor)
+    if not len(dataframes):
+        raise RuntimeError("No data was extracted? What's going on??")
     result = dataframes[0]
     for i in range(1, len(dataframes)):
         d = dataframes[i]

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -318,7 +318,10 @@ def load_single_dataset(run_id, treemakers, preselection, force_reload=False):
 
     # Apply pre-selection cuts before moving on to the next dataset
     for ps in preselection:
-        result = cuts.eval_selection(result, ps, quiet=True)
+        # For some reason when we do this through dask, the repetition check does not work properly.
+        # It isn't necessary here anyway, it's meant for use convenience.
+        # Hm... this sounds like there is some bigger problem or dark magic going on...
+        result = cuts.eval_selection(result, ps, quiet=True, force_repeat=True)
 
     return result, cuts.CUT_HISTORY.get(id(result), [])
 

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -299,12 +299,8 @@ def load_single_dataset(run_id, treemakers, preselection, force_reload=False):
             dataset_frame = load_single_minitree(run_id, treemaker, force_reload=force_reload)
         except NoMinitreeAvailable as e:
             log.debug(str(e))
-            continue
+            return pd.DataFrame([], columns=['event_number', 'run_number']), []
         dataframes.append(dataset_frame)
-
-    if not len(dataframes):
-        log.debug("None of the minitrees in this dataset were available")
-        return pd.DataFrame([], columns=['event_number', 'run_number']), {}
 
     # Merge mini-trees of all types by inner join
     # (propagating "cuts" applied by skipping rows in MultipleRowExtractor)

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -359,21 +359,21 @@ def load(datasets, treemakers=tuple(['Fundamentals', 'Basics']), preselection=No
         mashedup_result = dask.compute(*([result] + partial_histories),
                                        num_workers=num_workers, **compute_options)
         result = mashedup_result[0]
-        partial_histories = mashedup_result[1:]
-        # Combine the histories of partial results.
-        # For unavailable minitrees, the histories will be empty: filter these empty histories out
-        partial_histories = [x for x in partial_histories if len(x)]
-        if len(partial_histories):
-            cuts.record_combined_histories(result, partial_histories)
 
         if 'index' in result.columns:
             # Clean up index, remove 'index' column
             # Probably we're doing something weird with pandas, this doesn't seem like the well-trodden path...
-            # TODO: is this still triggered / necessary?
             log.debug("Removing weird index column")
             result.drop('index', axis=1, inplace=True)
             result = result.reset_index()
             result.drop('index', axis=1, inplace=True)
+
+        # Combine the histories of partial results.
+        # For unavailable minitrees, the histories will be empty: filter these empty histories out
+        partial_histories = mashedup_result[1:]
+        partial_histories = [x for x in partial_histories if len(x)]
+        if len(partial_histories):
+            cuts.record_combined_histories(result, partial_histories)
 
     else:
         # Magic for tracking of cut histories while using dask.dataframe here...

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -250,6 +250,11 @@ def load_single_minitree(run_id, treemaker, force_reload=False, return_metadata=
     if already_made:
         return get_format(minitree_path).load_data()
 
+    if not hax.config['make_minitrees']:
+        # The user didn't want me to make a new minitree :-( Return an empty dataframe
+        log.info("Minitree for %s not found, not creating it since make_minitrees is False.")
+        return pd.DataFrame()
+
     # We have to make the minitree file
     # This will raise FileNotFoundError if the root file is not found
     skimmed_data = treemaker().get_data(run_id)

--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -316,10 +316,7 @@ def load_single_dataset(run_id, treemakers, preselection, force_reload=False):
 
     # Apply pre-selection cuts before moving on to the next dataset
     for ps in preselection:
-        # For some reason when we do this through dask, the repetition check does not work properly.
-        # It isn't necessary here anyway, it's meant for use convenience.
-        # Hm... this sounds like there is some bigger problem or dark magic going on...
-        result = cuts.eval_selection(result, ps, quiet=True, force_repeat=True)
+        result = cuts.eval_selection(result, ps, quiet=True)
 
     return result, cuts.CUT_HISTORY.get(id(result), [])
 

--- a/hax/paxroot.py
+++ b/hax/paxroot.py
@@ -24,9 +24,7 @@ from hax.utils import find_file_in_folders
 log = logging.getLogger('hax.paxroot')
 
 
-def open_pax_rootfile(run_id, load_class=True):
-    """Opens pax root file for run_id, compiling classes/dictionaries as needed. Returns TFile object.
-    """
+def get_filename(run_id):
     try:
         run_name = runs.get_run_name(run_id)
         filename = runs.datasets.loc[runs.datasets['name'] == run_name].iloc[0].location
@@ -34,11 +32,19 @@ def open_pax_rootfile(run_id, load_class=True):
         print("Don't know a run named %s, trying to find it anyway..." % run_id)
         filename = find_file_in_folders(run_id + '.root', hax.config['main_data_paths'])
     if not filename:
-        raise ValueError("Cannot find processed data for run name %s." % run_name)
-    return _open_pax_rootfile(filename, load_class=True)
+        raise ValueError("Cannot find processed data for run name %s." % run_id)
 
-def _open_pax_rootfile(filename, load_class):
+
+def open_pax_rootfile(run_id, load_class=True):
+    """Opens pax root file for run_id, compiling classes/dictionaries as needed. Returns TFile object.
+    if load_class is False, will not load the event class. You'll only be able to read metadata from the file.
+    """
+    return _open_pax_rootfile(get_filename(run_id), load_class=load_class)
+
+
+def _open_pax_rootfile(filename, load_class=True):
     """Opens pax root file filename, compiling classes/dictionaries as needed. Returns TFile object.
+    if load_class is False, will not load the event class. You'll only be able to read metadata from the file.
     """
     if not os.path.exists(filename):
         raise ValueError("%s does not exist!" % filename)
@@ -57,7 +63,11 @@ def _open_pax_rootfile(filename, load_class):
 def get_metadata(run_id):
     """Returns the metadata dictionary stored in the pax root file for run_id.
     """
-    f = open_pax_rootfile(run_id, load_class=False)
+    return _get_metadata(get_filename(run_id))
+
+
+def _get_metadata(filename):
+    f = _open_pax_rootfile(filename, load_class=False)
     metadata = f.Get('pax_metadata').GetTitle()
     metadata = json.loads(metadata)
     f.Close()

--- a/hax/paxroot.py
+++ b/hax/paxroot.py
@@ -33,6 +33,7 @@ def get_filename(run_id):
         filename = find_file_in_folders(run_id + '.root', hax.config['main_data_paths'])
     if not filename:
         raise ValueError("Cannot find processed data for run name %s." % run_id)
+    return filename
 
 
 def open_pax_rootfile(run_id, load_class=True):

--- a/hax/paxroot.py
+++ b/hax/paxroot.py
@@ -11,7 +11,7 @@ from pax.exceptions import MaybeOldFormatException
 
 try:
     import ROOT
-    from pax.plugins.io.ROOTClass import load_event_class, load_pax_event_class_from_root
+    from pax.plugins.io.ROOTClass import load_event_class, load_pax_event_class_from_root, ShutUpROOT
 except ImportError as e:
     warnings.warn("Error importing ROOT-related libraries: %s. "
                   "If you try to use ROOT-related functions, hax will crash!" % e)
@@ -68,7 +68,9 @@ def get_metadata(run_id):
 
 
 def _get_metadata(filename):
-    f = _open_pax_rootfile(filename, load_class=False)
+    # Suppress warning about classes not being loaded (we're doing that on purpose)
+    with ShutUpROOT():
+        f = _open_pax_rootfile(filename, load_class=False)
     metadata = f.Get('pax_metadata').GetTitle()
     metadata = json.loads(metadata)
     f.Close()


### PR DESCRIPTION
This includes a few small changes:

* Hax no longer tries to compile the pax C++ event class if you're loading cached minitrees. This used to happen when hax checked if the minitree you're trying to load had the right verion of pax -- but for that you only need to peek at the metadata stored in the root file, not look at actual events. This should make loading of premade minitrees faster and less error-prone.

* Fix a bug in cut history tracking where new dataframes could "magically" inherit the histories of old dataframes after you'd deleted them. (turns out the `id` function in python gives memory addresses, not unique hash-like values...).

* Add a new option `make_minitrees` to hax init, which is True by default. If you set it to False, hax will silently (well, with just a debug message) skip datasets for which it can't find an up-to-date minitree. Not something you want to use for a big final serious physics analysis, but quite useful during development / prototyping. If you know what you're doing.
