### PR TITLE
Update TotalProperties

### DIFF
--- a/hax/treemakers/common.py
+++ b/hax/treemakers/common.py
@@ -175,16 +175,17 @@ class TotalProperties(TreeMaker):
     branch_selection = ['peaks.area', 'n_pulses', 'peaks.detector', 'interactions.s2', 'peaks.left', 'peaks.type']
 
     def extract_data(self, event):
+        peaks = event.peaks
         result = dict(n_pulses=event.n_pulses,
-                      n_peaks=len(event.peaks))
-        result['n_true_peaks'] = len([True for p in event.peaks if p.type != 'lone_hit'])
+                      n_peaks=len(peaks))
+        result['n_true_peaks'] = len([True for p in peaks if p.type != 'lone_hit'])
         result['total_peak_area'] = sum([p.area
-                                         for p in event.peaks
+                                         for p in peaks
                                          if p.detector == 'tpc'])
-        if len(interactions):
+        if len(event.interactions):
             main_s2_left = peaks[peaks.interactions[0].s2].left
             result['area_before_main_s2'] = sum([p.area
-                                                 for p in event.peaks
+                                                 for p in peaks
                                                  if p.detector == 'tpc' and p.left < main_s2_left])
         else:
             result['area_before_main_s2'] = 0

--- a/hax/treemakers/common.py
+++ b/hax/treemakers/common.py
@@ -183,7 +183,7 @@ class TotalProperties(TreeMaker):
                                          for p in peaks
                                          if p.detector == 'tpc'])
         if len(event.interactions):
-            main_s2_left = peaks[peaks.interactions[0].s2].left
+            main_s2_left = peaks[event.interactions[0].s2].left
             result['area_before_main_s2'] = sum([p.area
                                                  for p in peaks
                                                  if p.detector == 'tpc' and p.left < main_s2_left])


### PR DESCRIPTION
This updates the TotalProperties treemaker:

  * Fix #57; total_peak_area is now only computed on TPC peaks
  * Add `area_before_main_s2`, the total area in tpc peaks before the main S2. If there is no main S2 in the event, this number is 0.
  * Add `n_true_peaks`, the number of TPC peaks in the event, excluding lone hits. `n_peaks` is still the total number of peaks in all detectors (including lone hits, analog sum waveforms, etc.)

I've prepared updated minitrees for all pax_v6.2.0 data; after merging these we can copy them to the main folder.