### PR TITLE
Updating blinding cut to 99%

### DIFF
--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -96,7 +96,6 @@ trigger_data_special_path = None
 ##
 # Blinding cut
 ##
-#blinding_cut = '(cs1 > 15) & ((log(cs2/cs1)/log(10) > exp(-0.989158 + (-0.026168) * cs1) + 1.918830 + (-5.722440e-04) * cs1) | (cs1 > 200)' # old blinding defined on Rn220 October data
 blinding_cut  = '(log(cs2/cs1)/log(10) > exp(-0.720893+(-0.032622)*cs1) + 1.883038 + (-7.185652e-04)*cs1) | (cs1 > 200)'
 
 

--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -96,7 +96,8 @@ trigger_data_special_path = None
 ##
 # Blinding cut
 ##
-blinding_cut = '(cs1 > 15) & ((log(cs2/cs1)/log(10) > exp(-0.989158 + (-0.026168) * cs1) + 1.918830 + (-5.722440e-04) * cs1) | (cs1 > 200))'
+#blinding_cut = '(cs1 > 15) & ((log(cs2/cs1)/log(10) > exp(-0.989158 + (-0.026168) * cs1) + 1.918830 + (-5.722440e-04) * cs1) | (cs1 > 200)' # old blinding defined on Rn220 October data
+blinding_cut  = '(log(cs2/cs1)/log(10) > exp(-0.720893+(-0.032622)*cs1) + 1.883038 + (-7.185652e-04)*cs1) | (cs1 > 200)'
 
 
 ##


### PR DESCRIPTION
Updating blinding cut to 99% below ER band
99% line was determined from Rn220 data processed with pax version 6.4.2
dropping complete blinding below 15 PE in cs1