### PR TITLE
Option to mark minitrees as pax version independent

### DIFF
--- a/hax/minitrees.py
+++ b/hax/minitrees.py
@@ -41,6 +41,9 @@ class TreeMaker(object):
     uses_arrays = False         # Set to True if your treemaker returns array values. This will trigger a different
                                 # root file saving code.
 
+    # Set this to true if the treemaker results do not change with the pax version (e.g. for trigger information)
+    pax_version_independent = False
+
     def __init__(self):
         # Support for string arguments
         if isinstance(self.branch_selection, str):
@@ -215,7 +218,11 @@ def check(run_id, treemaker, force_reload=False):
 
     # Check if pax_version agrees with the version policy.
     version_policy = hax.config['pax_version_policy']
-    if version_policy == 'latest':
+
+    if treemaker.pax_version_independent:
+        return treemaker, True, minitree_path
+
+    elif version_policy == 'latest':
         # What the latest pax version is differs per dataset. We'll open the root file to find out
         # (you may think we can use the runs db info instead, but that won't work on e.g. MC root files)
         try:

--- a/hax/treemakers/common.py
+++ b/hax/treemakers/common.py
@@ -15,6 +15,7 @@ class Fundamentals(TreeMaker):
      - event_duration: duration (in ns) of the event
     """
     __version__ = '0.1'
+    pax_version_independent = True
     branch_selection = ['event_number', 'start_time', 'stop_time']
 
     def extract_data(self, event):

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -13,6 +13,7 @@ class LargestTriggeringSignal(TreeMaker):
      - trigger_*, where * is any of the attributes of datastructure.TriggerSignal
     """
     branch_selection = ['trigger_signals*', 'event_number']
+    pax_version_independent = True
     __version__ = '0.0.3'
 
     def extract_data(self, event):
@@ -44,6 +45,8 @@ class Proximity(hax.minitrees.TreeMaker):
      - 1e6_pe_event: "" 1e6 pe "
     """
     __version__ = '0.0.11'
+    pax_version_independent = True          # Well, the total peak area could change with the gain... neglect this.
+
     branch_selection = ['event_number', 'start_time', 'stop_time']
 
     aqm_labels = ['muon_veto_trigger', 'busy', 'hev']


### PR DESCRIPTION
If you set the attribute `pax_version_independent` to True for a treemaker, pax version checks will be disabled when loading it. Treemaker version checks are of course still performed. This is useful for Fundamentals, Proximity, etc. minitrees which do not have to be regenerated for each pax version (particularly for Proximity which is expensive to regenerate).