### PR TITLE
Updated proximity trees with new branches

### DIFF
--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -135,3 +135,30 @@ class Proximity(hax.minitrees.TreeMaker):
             result['nearest_s2_area'] = result['next_s2_area']
 
         return result
+
+class TailCut(hax.minitrees.TreeMaker):
+
+    __version__ = '0.0.2'
+
+    def get_data(self, dataset, event_list=None):
+
+        self.event_data = hax.minitrees.load_single_dataset(
+            dataset, ['Fundamentals', 'TotalProperties', 'LargestPeakProperties'])[0]
+        self.event_data['center_time'] = self.event_data.event_time + self.event_data.event_duration // 2
+        self.center_time = self.event_data.center_time.values
+        self.s2_area = self.event_data.s2_area.values
+        self.look_back=50
+        return hax.minitrees.TreeMaker.get_data(self, dataset, event_list)
+
+    def extract_data(self, event):
+
+        i = event.event_number
+        tnow = (event.start_time + event.stop_time) // 2
+
+        ct = self.center_time[i-self.look_back:i]
+        ls2 = self.s2_area[i-self.look_back:i]
+        try:
+            mp = max([ls2[i]/(tnow-ct[i]) for i in range(len(ct))])
+        except:
+            mp = None
+        return {"s2_over_tdiff": mp}

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -65,7 +65,7 @@ class Proximity(hax.minitrees.TreeMaker):
                              [(boundary + 'pe_event', event_data[event_data.total_peak_area >
                                                                eval(boundary)].center_time.values)
                                   for boundary in ['1e5', '3e5', '1e6']] +
-                             [('event', event_data.center_time.values)] 
+                             [('event', event_data.center_time.values)]
         )
         self.s2s = event_data.s2.values
 

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -95,7 +95,7 @@ class Proximity(hax.minitrees.TreeMaker):
                 result[prev] = t - x[i - 1]
                 if label == 'event':
                     result['previous_s2_area'] = self.s2s[i - 1]
-                
+
             # Check if the sought-after object is exactly at t
             # This is always true if label == 'event', only very rarely for aqm signals.
             # (but then we don't want to advance the 'next' index, it's important that the signal

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -88,13 +88,9 @@ class Proximity(hax.minitrees.TreeMaker):
                 i = np.searchsorted(x, t)   # Index in x of the first value >= t
 
             if i == 0:
-<<<<<<< a1b702c933ac0d1ff98a130ed3c2a9032c1c3420
                 result[prev] = 368395560000000000 # ~- int(np.inf).... 100th Birthday
-=======
-                result[prev] = float('inf')
                 if label == 'event':
-                    result['previous_s2_area'] = float('inf')
->>>>>>> Updated proximity trees with new branches
+                    result['previous_s2_area'] = 368395560000000000
             else:
                 result[prev] = t - x[i - 1]
                 if label == 'event':
@@ -111,13 +107,9 @@ class Proximity(hax.minitrees.TreeMaker):
                 assert label != 'event'
 
             if i == len(x):
-<<<<<<< a1b702c933ac0d1ff98a130ed3c2a9032c1c3420
-                result[nxt] = 368395560000000000 # ~- int(np.inf).... 100th Birthday
-=======
-                result[nxt] = float('inf')
+                result[nxt] = 368395560000000000
                 if label == 'event':
-                    result['next_s2_area'] = float('inf')
->>>>>>> Updated proximity trees with new branches
+                    result['next_s2_area'] = 368395560000000000
             else:
                 result[nxt] = x[i] - t
                 if label == 'event':

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -37,26 +37,25 @@ class Proximity(hax.minitrees.TreeMaker):
 
     x denotes the object of interest, and could be either:
      - muon_veto_trigger.
-     - busy: a busy-on or busy-off signal
-     - hev: a high-energy veto on or -off signal
+     - busy_x: a busy-on or busy-off signal
+     - hev_x: a high-energy veto on or -off signal
      - event: any event (excluding itself :-)
      - 1e5_pe_event: any event with total peak area > 1e5 pe (excluding itself)
      - 3e5_pe_event: "" 3e5 pe "
      - 1e6_pe_event: "" 1e6 pe "
+     - s2_area: Area of main s2 in event
     """
-    __version__ = '0.0.11'
-    pax_version_independent = True          # Well, the total peak area could change with the gain... neglect this.
+    __version__ = '0.0.12'
+    pax_version_independent = False          # Now that we include S2 area it's not
 
-    branch_selection = ['event_number', 'start_time', 'stop_time']
-
-    aqm_labels = ['muon_veto_trigger', 'busy', 'hev']
+    aqm_labels = ['muon_veto_trigger', 'busy_on', 'hev_on', 'busy_off', 'hev_off', 'busy', 'hev']
 
     def get_data(self, dataset, event_list=None):
         aqm_pulses = get_aqm_pulses(dataset)
 
         # Load the fundamentals and totalproperties minitree
         # Yes, minitrees loading other minitrees, the fun has begun :-)
-        event_data = hax.minitrees.load_single_dataset(dataset, ['Fundamentals', 'TotalProperties'])[0]
+        event_data = hax.minitrees.load_single_dataset(dataset, ['Fundamentals', 'TotalProperties', 'Basics'])[0]
         # Note integer division here, not optional: float arithmetic is too inprecise
         # (fortuately our digitizer sampling resolution is an even number of nanoseconds...)
         event_data['center_time'] = event_data.event_time + event_data.event_duration // 2
@@ -66,7 +65,9 @@ class Proximity(hax.minitrees.TreeMaker):
                              [(boundary + 'pe_event', event_data[event_data.total_peak_area >
                                                                eval(boundary)].center_time.values)
                                   for boundary in ['1e5', '3e5', '1e6']] +
-                             [('event', event_data.center_time.values)])
+                             [('event', event_data.center_time.values)] 
+        )
+        self.s2s = event_data.s2.values
 
         # super() does not play nice with dask computations, for some reason
         return hax.minitrees.TreeMaker.get_data(self, dataset, event_list)
@@ -87,10 +88,18 @@ class Proximity(hax.minitrees.TreeMaker):
                 i = np.searchsorted(x, t)   # Index in x of the first value >= t
 
             if i == 0:
+<<<<<<< a1b702c933ac0d1ff98a130ed3c2a9032c1c3420
                 result[prev] = 368395560000000000 # ~- int(np.inf).... 100th Birthday
+=======
+                result[prev] = float('inf')
+                if label == 'event':
+                    result['previous_s2_area'] = float('inf')
+>>>>>>> Updated proximity trees with new branches
             else:
                 result[prev] = t - x[i - 1]
-
+                if label == 'event':
+                    result['previous_s2_area'] = self.s2s[i - 1]
+                
             # Check if the sought-after object is exactly at t
             # This is always true if label == 'event', only very rarely for aqm signals.
             # (but then we don't want to advance the 'next' index, it's important that the signal
@@ -102,10 +111,18 @@ class Proximity(hax.minitrees.TreeMaker):
                 assert label != 'event'
 
             if i == len(x):
+<<<<<<< a1b702c933ac0d1ff98a130ed3c2a9032c1c3420
                 result[nxt] = 368395560000000000 # ~- int(np.inf).... 100th Birthday
+=======
+                result[nxt] = float('inf')
+                if label == 'event':
+                    result['next_s2_area'] = float('inf')
+>>>>>>> Updated proximity trees with new branches
             else:
                 result[nxt] = x[i] - t
-
+                if label == 'event':
+                    result['next_s2_area'] = self.s2s[i]
+                    
             # Include the 'nearest' variable. This is negative if the nearest sought-after object
             # is in the past.
             tnr = 'nearest_' + label
@@ -114,4 +131,10 @@ class Proximity(hax.minitrees.TreeMaker):
             else:
                 result[tnr] = result[nxt]
 
+        # Need special logic for nearest s2 area
+        if result['nearest_event'] == result['previous_event']:
+            result['nearest_s2_area'] = result['previous_s2_area']
+        else:
+            result['nearest_s2_area'] = result['next_s2_area']
+            
         return result

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -128,5 +128,5 @@ class Proximity(hax.minitrees.TreeMaker):
             result['nearest_s2_area'] = result['previous_s2_area']
         else:
             result['nearest_s2_area'] = result['next_s2_area']
-            
+
         return result

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -55,7 +55,7 @@ class Proximity(hax.minitrees.TreeMaker):
 
         # Load the fundamentals and totalproperties minitree
         # Yes, minitrees loading other minitrees, the fun has begun :-)
-        event_data = hax.minitrees.load_single_dataset(dataset, ['Fundamentals', 'TotalProperties', 'Basics'])[0]
+        event_data = hax.minitrees.load_single_dataset(dataset, ['Fundamentals', 'TotalProperties', 'LargestPeakProperties'])[0]
         # Note integer division here, not optional: float arithmetic is too inprecise
         # (fortuately our digitizer sampling resolution is an even number of nanoseconds...)
         event_data['center_time'] = event_data.event_time + event_data.event_duration // 2
@@ -67,7 +67,7 @@ class Proximity(hax.minitrees.TreeMaker):
                                   for boundary in ['1e5', '3e5', '1e6']] +
                              [('event', event_data.center_time.values)]
         )
-        self.s2s = event_data.s2.values
+        self.s2s = event_data.s2_area.values
 
         # super() does not play nice with dask computations, for some reason
         return hax.minitrees.TreeMaker.get_data(self, dataset, event_list)
@@ -104,8 +104,13 @@ class Proximity(hax.minitrees.TreeMaker):
                 # The real 'next' is one further:
                 i += 1
             else:
-                assert label != 'event'
-
+                try:
+                    assert label != 'event'
+                except:
+                    print(x[i])
+                    print(t)
+                    raise
+                    
             if i == len(x):
                 result[nxt] = 368395560000000000
                 if label == 'event':

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -114,7 +114,7 @@ class Proximity(hax.minitrees.TreeMaker):
                 result[nxt] = x[i] - t
                 if label == 'event':
                     result['next_s2_area'] = self.s2s[i]
-                    
+
             # Include the 'nearest' variable. This is negative if the nearest sought-after object
             # is in the past.
             tnr = 'nearest_' + label

--- a/hax/treemakers/trigger.py
+++ b/hax/treemakers/trigger.py
@@ -110,7 +110,7 @@ class Proximity(hax.minitrees.TreeMaker):
                     print(x[i])
                     print(t)
                     raise
-                    
+
             if i == len(x):
                 result[nxt] = 368395560000000000
                 if label == 'event':
@@ -159,6 +159,6 @@ class TailCut(hax.minitrees.TreeMaker):
         ls2 = self.s2_area[i-self.look_back:i]
         try:
             mp = max([ls2[i]/(tnow-ct[i]) for i in range(len(ct))])
-        except:
+        except Exception:
             mp = None
         return {"s2_over_tdiff": mp}


### PR DESCRIPTION
Adds the following:

previous_busy_on
next_busy_on
nearest_busy_on

previous_hev_on
next_hev_on
nearest_hev_on

previous_s2_area
next_s2_area
nearest_s2_area

The former are to include in the DAQ cut for the 'sub-prime' period. The latter is for the self-veto cut.