### PR TITLE
update blinding cut to new 2-sigma ER line

### DIFF
--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -99,7 +99,7 @@ trigger_data_special_path = None
 ##
 # Blinding cut
 ##
-blinding_cut  = '(log(cs2_bottom/cs1)/log(10) > 0.374125*exp(-cs1/33.5861) + 1.43559 -0.000755488*cs1 + 1.33334/cs1 | (cs1 > 200) | (s2<150) | (largest_other_s2>200)'
+blinding_cut  = '(log(cs2_bottom/cs1)/log(10) > 0.374125*exp(-cs1/33.5861) + 1.43559 -0.000755488*cs1 + 1.33334/cs1) | (cs1 > 200) | (s2<150) | (largest_other_s2>200)'
 blind_from_run = 3936
 
 ##

--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -99,7 +99,7 @@ trigger_data_special_path = None
 ##
 # Blinding cut
 ##
-blinding_cut  = '(log(cs2/cs1)/log(10) > exp(-0.720893+(-0.032622)*cs1) + 1.883038 + (-7.185652e-04)*cs1) | (cs1 > 200) | (s2<150) | (largest_other_s2>200)'
+blinding_cut  = '(log(cs2_bottom/cs1)/log(10) > 0.374125*exp(-cs1/33.5861) + 1.43559 -0.000755488*cs1 + 1.33334/cs1 | (cs1 > 200) | (s2<150) | (largest_other_s2>200)'
 blind_from_run = 3936
 
 ##

--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -98,8 +98,9 @@ trigger_data_special_path = None
 
 ##
 # Blinding cut
+# We're blinding low energy NG (1st term), 2 e- capture from 50-80 keV (2nd term), and 0nbb 2.3-2.6 MeV (3rd term)
 ##
-blinding_cut  = '(log(cs2_bottom/cs1)/log(10) > 0.374125*exp(-cs1/33.5861) + 1.43559 -0.000755488*cs1 + 1.33334/cs1) | (cs1 > 200) | (s2<150) | (largest_other_s2>200)'
+blinding_cut  = '((log(cs2_bottom/cs1)/log(10) > 0.374125*exp(-cs1/33.5861) + 1.43559 -0.000755488*cs1 + 1.33334/cs1) | (cs1 > 200) | (s2<150) | (largest_other_s2>200))&((0.0137*(cs1/.1469 + cs2_bottom/100/11.13) < 50.) | (0.0137*(cs1/.1469 + cs2_bottom/100/11.13) > 80.))&((0.0137*(cs1/.1469 + cs2_bottom/100/11.13) < 2300.) | (0.0137*(cs1/.1469 + cs2_bottom/100/11.13) > 2600.))'
 blind_from_run = 3936
 
 ##

--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -100,7 +100,7 @@ trigger_data_special_path = None
 # Blinding cut
 # We're blinding low energy NG (1st term), 2 e- capture from 50-80 keV (2nd term), and 0nbb 2.3-2.6 MeV (3rd term)
 ##
-blinding_cut  = '((log(cs2_bottom/cs1)/log(10) > 0.374125*exp(-cs1/33.5861) + 1.43559 -0.000755488*cs1 + 1.33334/cs1) | (cs1 > 200) | (s2<150) | (largest_other_s2>200))&((0.0137*(cs1/.1469 + cs2_bottom/100/11.13) < 50.) | (0.0137*(cs1/.1469 + cs2_bottom/100/11.13) > 80.))&((0.0137*(cs1/.1469 + cs2_bottom/100/11.13) < 2300.) | (0.0137*(cs1/.1469 + cs2_bottom/100/11.13) > 2600.))'
+blinding_cut  = '((log(cs2_bottom/cs1)/log(10) > 0.374125*exp(-cs1/33.5861) + 1.43559 -0.000755488*cs1 + 1.33334/cs1) | (cs1 > 200) | (s2<150) | (largest_other_s2>200))&((0.0137*(cs1/.1469 + cs2_bottom/11.13) < 50.) | (0.0137*(cs1/.1469 + cs2_bottom/11.13) > 80.))&((0.0137*(cs1/.1469 + cs2_bottom/11.13) < 2300.) | (0.0137*(cs1/.1469 + cs2_bottom/11.13) > 2600.))'
 blind_from_run = 3936
 
 ##


### PR DESCRIPTION
2-sigma ER taken from Shingo's note here: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:kazama:anomalous_bg_sr1#appendix_2er_nr-band_lines_estimated_with_pax_v680_3d_fdc_and_1300_kg_fv

Note that this changes the definition to cs2_bottom instead of cs2 as it was.

I tested this quickly on a couple runs of rn220_tail data with no cuts, which should be safe, and it looks good. It would be nice if a second person tested as well before deploying.
