### PR TITLE
Don't query db for every run's blinding status

### DIFF
--- a/hax/cuts.py
+++ b/hax/cuts.py
@@ -203,7 +203,7 @@ def range_cuts(*args, **kwargs):
     range_selections(*args, **kwargs)
 
 
-def apply_lichen(data, lichen_names, lichen_file='sciencerun0', **kwargs):
+def apply_lichen(data, lichen_names, lichen_file='sciencerun1', **kwargs):
     """Apply cuts defined by the lax lichen(s) lichen_names from the lichen_file to data.
     """
     # Support for single lichen
@@ -222,17 +222,19 @@ def apply_lichen(data, lichen_names, lichen_file='sciencerun0', **kwargs):
         # .copy() to prevent pandas warning and pollution with new columns
         d = lichen().process(data.copy())
 
-        data = selection(data, getattr(d, 'Cut' + lichen_name),
-                         desc=lichen_name + ((' v%d' % lichen.version)
-                                             if hasattr(lichen, 'version') and not np.isnan(lichen.version)
-                                             else (' (lax v%s)' % lax.__version__)), **kwargs)
+        desc = lichen_name
+        if hasattr(lichen, 'version'):
+            desc += ' v' + str(lichen.version)
+        else:
+            desc += ' (lax v%s)' % lax.__version__
+
+        data = selection(data, getattr(d, 'Cut' + lichen_name), desc=desc, **kwargs)
 
     return data
 
 ##
 # pandas.DataFrame.eval selections
 ##
-
 
 def eval_selection(d, eval_string, **kwargs):
     """Apply a selection specified by a pandas.DataFrame.eval string that returns the boolean array.


### PR DESCRIPTION
When you load all SR0 bg datasets (~4000), you have to wait ~9 minutes before hax starts loading the minitrees. During this time it's querying the runs db (one query / run) to fetch some info for the decision whether or not to apply the blinding cut (name, number, tags). However, hax has already queried this info when you do hax.init(). This fixes hax to use that info instead, cutting the initialization time of the minitrees load call down to a few seconds at most.

I also changed get_run_number to raise an exception rather than return 0 when it cannot find a run.

Test code (100 datasets):

    %%time
    results = np.zeros(100)
    for i, run_i in enumerate(6666 + np.arange(100)):
        results[i] = hax.runs.is_blind(run_i)
    print("%d are blind" % results.sum())

Before:

    81 are blind
    CPU times: user 588 ms, sys: 38.1 ms, total: 626 ms
    Wall time: 14.3 s


After:

    81 are blind
    CPU times: user 312 ms, sys: 12.5 ms, total: 325 ms
    Wall time: 318 ms

