### PR TITLE
Update time-dependent 3D FDC run bins for SR1

### DIFF
--- a/hax/hax.ini
+++ b/hax/hax.ini
@@ -130,10 +130,10 @@ corrections_definitions = {
     ],
     "fdc_3d": [
         {"run_min": 0, "run_max": 6385, "correction": "FDC_SR0_data_driven_3d_correction_v0.json.gz"},
-        {"run_min": 6386, "run_max": 8245, "correction": "FDC_SR1_data_driven_time_dependent_3d_correction_part1_v1.json.gz"},
-        {"run_min": 8246, "run_max": 10222, "correction": "FDC_SR1_data_driven_time_dependent_3d_correction_part2_v1.json.gz"},
-        {"run_min": 10223, "run_max": 12089, "correction": "FDC_SR1_data_driven_time_dependent_3d_correction_part3_v1.json.gz"},
-        {"run_min": 12090, "correction": "FDC_SR1_data_driven_time_dependent_3d_correction_part4_v1.json.gz"}
+        {"run_min": 6386, "run_max": 8755, "correction": "FDC_SR1_data_driven_time_dependent_3d_correction_part1_v3.json.gz"},
+        {"run_min": 8756, "run_max": 11193, "correction": "FDC_SR1_data_driven_time_dependent_3d_correction_part2_v3.json.gz"},
+        {"run_min": 11194, "run_max": 13502, "correction": "FDC_SR1_data_driven_time_dependent_3d_correction_part3_v3.json.gz"},
+        {"run_min": 13503, "correction": "FDC_SR1_data_driven_time_dependent_3d_correction_part4_v3.json.gz"}
     ],
     "fdc_3d_tfnn": [
         {"run_min": 0, "run_max": 6385, "correction": "FDC_SR0_data_driven_3d_correction_tf_nn_v0.json.gz"},


### PR DESCRIPTION
Update 3D FDC as we have more Kr data. See here:
https://github.com/XENON1T/pax/pull/662/commits/941ebfeb60e5760d6e7c119da4c4e2bc1a49dd88