### PR TITLE
Adding S2PatternReducedAP minitree

### DIFF
--- a/hax/treemakers/pattern.py
+++ b/hax/treemakers/pattern.py
@@ -215,7 +215,7 @@ class S2PatternReducedAP(TreeMaker):
     '''
     Determination of the S2PatternLikelihood value when excluding PMTs that show large After-Pulse during SR1. TO DO : Check for SR2.
     Allow to reduce the time dependance of the S2PatternLikelihood value used for cuts (see:https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:chloetherreau:0vbb_s2_likelihood_cut_he_update#update_s2_pattern_likelihood_cut_at_high_energy_with_position_dependance)
-    
+    Need Correction and Fundamentals minitrees.
     '''
     __version__ = '1.0'
     extra_branches = ['peaks.area_per_channel*']

--- a/hax/treemakers/pattern.py
+++ b/hax/treemakers/pattern.py
@@ -10,6 +10,10 @@ from pax.plugins.interaction_processing.S1AreaFractionTopProbability import s1_a
 from hax.corrections_handler import CorrectionsHandler
 
 
+from collections import defaultdict
+from pax import units, configuration, datastructure
+pax_config = configuration.load_configuration('XENON1T')
+
 class PatternReconstruction(TreeMaker):
     """Stores interaction pattern-related variables.
 
@@ -205,3 +209,90 @@ class PatternReconstruction(TreeMaker):
             return event_data
 
         return event_data
+
+
+class S2PatternReducedAP(TreeMaker):
+    '''
+    Determination of the S2PatternLikelihood value when excluding PMTs that show large After-Pulse during SR1. TO DO : Check for SR2.
+    Allow to reduce the time dependance of the S2PatternLikelihood value used for cuts (see:https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:chloetherreau:0vbb_s2_likelihood_cut_he_update#update_s2_pattern_likelihood_cut_at_high_energy_with_position_dependance)
+    
+    '''
+    __version__ = '1.0'
+    extra_branches = ['peaks.area_per_channel*']
+    def __init__(self):
+        hax.minitrees.TreeMaker.__init__(self)
+      
+        # We need to pull some stuff from the pax config
+        self.pax_config = load_configuration("XENON1T")
+        self.channels_tot = self.pax_config['DEFAULT']['channels_in_detector']
+
+        self.channels_top = self.pax_config['DEFAULT']['channels_top']
+        self.is_pmt_alive = np.array(self.pax_config['DEFAULT']['gains']) > 1
+     
+        qes = np.array(self.pax_config['DEFAULT']['quantum_efficiencies'])
+        
+        # Create PMT array of booleans for use in likelihood calculation
+        #self.is_pmt_in= np.ones(len(self.channels_top), dtype=bool)  # Default True
+        self.is_pmt_in=self.is_pmt_alive[self.channels_top]
+        # After Pulse Channel 
+        self.apc = self.pax_config['DesaturatePulses.DesaturatePulses']['large_after_pulsing_channels']
+        self.apc_top = list(set(self.apc).intersection(
+            self.pax_config['DEFAULT']['channels_top']))
+        self.s2_pattern_fitter = PatternFitter(
+                    filename=utils.data_file_name(self.pax_config['WaveformSimulator']['s2_fitted_patterns_file']),
+                    zoom_factor=self.pax_config['WaveformSimulator'].get('s2_fitted_patterns_zoom_factor', 1),
+                    adjust_to_qe=qes[self.channels_top],
+                    default_errors=(self.pax_config['DEFAULT']['relative_qe_error'] + 
+                                   self.pax_config['DEFAULT']['relative_gain_error'])
+        )
+    def get_data(self, dataset, event_list=None):
+        # If we do switch to new NN later get rid of this stuff and directly use those positions!
+        # WARNING: This 'bypass_blinding' flag should only be used for production and never for analysis (see #211)
+        data, _ = hax.minitrees.load_single_dataset(dataset, ['Corrections', 'Fundamentals'])
+        self.x = data.x_observed_nn_tf.values
+        self.y = data.y_observed_nn_tf.values
+        self.z = data.z_observed.values
+        self.indices = list(data.event_number.values)
+        return hax.minitrees.TreeMaker.get_data(self, dataset, event_list)
+        
+    def extract_data(self, event):
+        result = dict()
+        # If there are no interactions cannot do anything
+        if not len(event.interactions):
+            return result
+        interaction = event.interactions[0]
+        s2 = event.peaks[interaction.s2]
+
+        result['s2_area_from_top_ap_pmt'] = np.sum(
+            np.array(list(s2.area_per_channel))[self.apc_top])
+        event_num = event.event_number
+        try:
+            event_index = self.indices.index(event_num)
+        except Exception:
+            return result
+        area_per_channel = np.array(list(s2.area_per_channel))[self.channels_top]
+
+        # Pattern fit with all PMTs
+        try:
+            result['s2_pattern_fit_top']=self.s2_pattern_fitter.compute_gof(
+                coordinates=(self.x[event_index], self.y[event_index]),
+                areas_observed=area_per_channel,
+                pmt_selection=self.is_pmt_in,
+                statistic='likelihood_poisson')
+        except exceptions.CoordinateOutOfRangeException as _:
+            # pax does this too. happens when event out of TPC (usually z)
+            return result
+            
+        # Remove all PMT AP channel
+        self.is_pmt_in[self.apc_top] = False
+        #self.is_pmt_in[self.is_pmt_alive] = True
+        try:
+            result['s2_pattern_fit_top_reduced_ap']=self.s2_pattern_fitter.compute_gof(
+                coordinates=(self.x[event_index], self.y[event_index]),
+                areas_observed=area_per_channel,
+                pmt_selection=self.is_pmt_in,
+                statistic='likelihood_poisson')
+        except exceptions.CoordinateOutOfRangeException as _:
+            # pax does this too. happens when event out of TPC (usually z)
+            return result
+        return result

--- a/hax/treemakers/pattern.py
+++ b/hax/treemakers/pattern.py
@@ -9,9 +9,7 @@ from pax import exceptions
 from pax.plugins.interaction_processing.S1AreaFractionTopProbability import s1_area_fraction_top_probability
 from hax.corrections_handler import CorrectionsHandler
 
-
-from collections import defaultdict
-from pax import units, configuration, datastructure
+from pax import configuration, datastructure
 pax_config = configuration.load_configuration('XENON1T')
 
 class PatternReconstruction(TreeMaker):
@@ -213,28 +211,29 @@ class PatternReconstruction(TreeMaker):
 
 class S2PatternReducedAP(TreeMaker):
     '''
-    Determination of the S2PatternLikelihood value when excluding PMTs that show large After-Pulse during SR1. TO DO : Check for SR2.
-    Allow to reduce the time dependance of the S2PatternLikelihood value used for cuts (see:https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:chloetherreau:0vbb_s2_likelihood_cut_he_update#update_s2_pattern_likelihood_cut_at_high_energy_with_position_dependance)
+    Determination of the S2PatternLikelihood value when excluding PMTs that show large After-Pulse during SR1. 
+    TO DO : Check for SR2.
+    Allow to reduce the time dependance of the S2PatternLikelihood value used for cuts 
+    (see:https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:chloetherreau:0vbb_s2_likelihood_cut_he_update)
     Need Correction and Fundamentals minitrees.
     '''
     __version__ = '1.0'
     extra_branches = ['peaks.area_per_channel*']
+    
     def __init__(self):
         hax.minitrees.TreeMaker.__init__(self)
-      
         # We need to pull some stuff from the pax config
         self.pax_config = load_configuration("XENON1T")
         self.channels_tot = self.pax_config['DEFAULT']['channels_in_detector']
 
         self.channels_top = self.pax_config['DEFAULT']['channels_top']
         self.is_pmt_alive = np.array(self.pax_config['DEFAULT']['gains']) > 1
-     
+
         qes = np.array(self.pax_config['DEFAULT']['quantum_efficiencies'])
-        
+
         # Create PMT array of booleans for use in likelihood calculation
-        #self.is_pmt_in= np.ones(len(self.channels_top), dtype=bool)  # Default True
-        self.is_pmt_in=self.is_pmt_alive[self.channels_top]
-        # After Pulse Channel 
+        self.is_pmt_in = self.is_pmt_alive[self.channels_top]
+        # After Pulse Channel
         self.apc = self.pax_config['DesaturatePulses.DesaturatePulses']['large_after_pulsing_channels']
         self.apc_top = list(set(self.apc).intersection(
             self.pax_config['DEFAULT']['channels_top']))
@@ -243,8 +242,8 @@ class S2PatternReducedAP(TreeMaker):
                     zoom_factor=self.pax_config['WaveformSimulator'].get('s2_fitted_patterns_zoom_factor', 1),
                     adjust_to_qe=qes[self.channels_top],
                     default_errors=(self.pax_config['DEFAULT']['relative_qe_error'] + 
-                                   self.pax_config['DEFAULT']['relative_gain_error'])
-        )
+                                    self.pax_config['DEFAULT']['relative_gain_error']))
+
     def get_data(self, dataset, event_list=None):
         # If we do switch to new NN later get rid of this stuff and directly use those positions!
         # WARNING: This 'bypass_blinding' flag should only be used for production and never for analysis (see #211)
@@ -254,7 +253,7 @@ class S2PatternReducedAP(TreeMaker):
         self.z = data.z_observed.values
         self.indices = list(data.event_number.values)
         return hax.minitrees.TreeMaker.get_data(self, dataset, event_list)
-        
+    
     def extract_data(self, event):
         result = dict()
         # If there are no interactions cannot do anything
@@ -274,7 +273,7 @@ class S2PatternReducedAP(TreeMaker):
 
         # Pattern fit with all PMTs
         try:
-            result['s2_pattern_fit_top']=self.s2_pattern_fitter.compute_gof(
+            result['s2_pattern_fit_top'] = self.s2_pattern_fitter.compute_gof(
                 coordinates=(self.x[event_index], self.y[event_index]),
                 areas_observed=area_per_channel,
                 pmt_selection=self.is_pmt_in,
@@ -282,12 +281,12 @@ class S2PatternReducedAP(TreeMaker):
         except exceptions.CoordinateOutOfRangeException as _:
             # pax does this too. happens when event out of TPC (usually z)
             return result
-            
+
         # Remove all PMT AP channel
         self.is_pmt_in[self.apc_top] = False
-        #self.is_pmt_in[self.is_pmt_alive] = True
+
         try:
-            result['s2_pattern_fit_top_reduced_ap']=self.s2_pattern_fitter.compute_gof(
+            result['s2_pattern_fit_top_reduced_ap'] = self.s2_pattern_fitter.compute_gof(
                 coordinates=(self.x[event_index], self.y[event_index]),
                 areas_observed=area_per_channel,
                 pmt_selection=self.is_pmt_in,

--- a/hax/treemakers/pattern.py
+++ b/hax/treemakers/pattern.py
@@ -278,7 +278,7 @@ class S2PatternReducedAP(TreeMaker):
                 areas_observed=area_per_channel,
                 pmt_selection=self.is_pmt_in,
                 statistic='likelihood_poisson')
-        except exceptions.CoordinateOutOfRangeException as _:
+        except exceptions.CoordinateOutOfRangeException :
             # pax does this too. happens when event out of TPC (usually z)
             return result
 
@@ -291,7 +291,7 @@ class S2PatternReducedAP(TreeMaker):
                 areas_observed=area_per_channel,
                 pmt_selection=self.is_pmt_in,
                 statistic='likelihood_poisson')
-        except exceptions.CoordinateOutOfRangeException as _:
+        except exceptions.CoordinateOutOfRangeException :
             # pax does this too. happens when event out of TPC (usually z)
             return result
         return result

--- a/hax/treemakers/pattern.py
+++ b/hax/treemakers/pattern.py
@@ -278,7 +278,7 @@ class S2PatternReducedAP(TreeMaker):
                 areas_observed=area_per_channel,
                 pmt_selection=self.is_pmt_in,
                 statistic='likelihood_poisson')
-        except exceptions.CoordinateOutOfRangeException :
+        except exceptions.CoordinateOutOfRangeException:
             # pax does this too. happens when event out of TPC (usually z)
             return result
 
@@ -291,7 +291,7 @@ class S2PatternReducedAP(TreeMaker):
                 areas_observed=area_per_channel,
                 pmt_selection=self.is_pmt_in,
                 statistic='likelihood_poisson')
-        except exceptions.CoordinateOutOfRangeException :
+        except exceptions.CoordinateOutOfRangeException:
             # pax does this too. happens when event out of TPC (usually z)
             return result
         return result

--- a/hax/treemakers/pattern.py
+++ b/hax/treemakers/pattern.py
@@ -9,7 +9,7 @@ from pax import exceptions
 from pax.plugins.interaction_processing.S1AreaFractionTopProbability import s1_area_fraction_top_probability
 from hax.corrections_handler import CorrectionsHandler
 
-from pax import configuration, datastructure
+from pax import configuration
 pax_config = configuration.load_configuration('XENON1T')
 
 class PatternReconstruction(TreeMaker):
@@ -211,15 +211,15 @@ class PatternReconstruction(TreeMaker):
 
 class S2PatternReducedAP(TreeMaker):
     '''
-    Determination of the S2PatternLikelihood value when excluding PMTs that show large After-Pulse during SR1. 
+    Determination of the S2PatternLikelihood value when excluding PMTs that show large After-Pulse during SR1.
     TO DO : Check for SR2.
-    Allow to reduce the time dependance of the S2PatternLikelihood value used for cuts 
+    Allow to reduce the time dependance of the S2PatternLikelihood value used for cuts
     (see:https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:chloetherreau:0vbb_s2_likelihood_cut_he_update)
     Need Correction and Fundamentals minitrees.
     '''
     __version__ = '1.0'
     extra_branches = ['peaks.area_per_channel*']
-    
+
     def __init__(self):
         hax.minitrees.TreeMaker.__init__(self)
         # We need to pull some stuff from the pax config
@@ -241,7 +241,7 @@ class S2PatternReducedAP(TreeMaker):
                     filename=utils.data_file_name(self.pax_config['WaveformSimulator']['s2_fitted_patterns_file']),
                     zoom_factor=self.pax_config['WaveformSimulator'].get('s2_fitted_patterns_zoom_factor', 1),
                     adjust_to_qe=qes[self.channels_top],
-                    default_errors=(self.pax_config['DEFAULT']['relative_qe_error'] + 
+                    default_errors=(self.pax_config['DEFAULT']['relative_qe_error'] +
                                     self.pax_config['DEFAULT']['relative_gain_error']))
 
     def get_data(self, dataset, event_list=None):
@@ -253,7 +253,7 @@ class S2PatternReducedAP(TreeMaker):
         self.z = data.z_observed.values
         self.indices = list(data.event_number.values)
         return hax.minitrees.TreeMaker.get_data(self, dataset, event_list)
-    
+
     def extract_data(self, event):
         result = dict()
         # If there are no interactions cannot do anything


### PR DESCRIPTION
Add S2PatternReducedAP minitree in order to reduce the time dependance of S2PatternLikelihood value. 
 see this note for more details : https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:chloetherreau:0vbb_s2_likelihood_cut_he_update#update_s2_pattern_likelihood_cut_at_high_energy_with_position_dependance