### PR TITLE
Unblind DEC region in SR2

### DIFF
--- a/hax/unblinding.py
+++ b/hax/unblinding.py
@@ -66,6 +66,8 @@ unblind['dec']['i125_after_NG'] = '((run_number>17580) & (run_number<=17820))'
 
 # Unblinding of SR0 and SR1 in the DEC (see #228)
 unblind['dec']['SR1'] = '(run_number<=16639)'
+# Unblinding of SR2
+unblind['dec']['SR2'] = '(run_number>16639)'
 
 
 # 0vbb blinded from 2.3-2.6 MeV (see #161)
@@ -76,20 +78,6 @@ unblind['0vbb']['e_range'] = \
 
 # HE multiple scatter
 unblind['0vbb']['multiple_scatter'] = '(largest_other_s2 > 10000) & (largest_other_s2 > 0.2 * s2)'
-
-
-# blind the low-energy ER part
-# unblind['low_energy_er'] = {}
-# unblind['low_energy_er']['e_range'] = \
-#     '(0.0137*(cs1/(z_3d_nn*0.000092 + 0.14628) + cs2_bottom/(-0.017*z_3d_nn + 10.628)) > 0)'
-# unblind['low_energy_er']['SR1'] = '(run_number<=16639)'
-# # unblind the region outside ER 3sigma
-# # reference: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:mcfate:for_er_band_3sigma
-# unblind['low_energy_er']['lower_3sigma'] = \
-#     '(log(cs2_bottom)/log(10) < 2.91587106 + 0.00373425412*cs1 - 0.705558565*exp(-cs1/11.3520824))'
-# unblind['low_energy_er']['upper_3sigma'] = \
-#     '(log(cs2_bottom)/log(10) > 3.46448943 + 0.00312699434*cs1 - 0.261867413*exp(-cs1/17.6341675))'
-
 
 def make_unblinding_selection():
     """Generate full unblinding selection string


### PR DESCRIPTION
This should unblind the DEC region for all XENON1T data (SR0 and SR1 already unblinded). We've discussed in meetings in the past but it would be good to get confirmation from DEC group (@cwittweg) that this is okay before merging.
