### PR TITLE
Bump Corrections treemaker 2.4 --> 2.5

### DIFF
--- a/hax/treemakers/corrections.py
+++ b/hax/treemakers/corrections.py
@@ -100,7 +100,7 @@ class Corrections(TreeMaker):
     for electron lifetime and x, y dependence.
 
     """
-    __version__ = '2.4'
+    __version__ = '2.5'
     extra_branches = ['peaks.area_per_channel[260]',
                       'peaks.n_saturated_per_channel[260]',
                       'peaks.s2_saturation_correction',


### PR DESCRIPTION
The electron lifetime model (v 1.0) has been updated, so this change is needed for regrowing minitrees.